### PR TITLE
Subnet-Only Validators (SOVs)

### DIFF
--- a/ACPs/TEMPLATE.md
+++ b/ACPs/TEMPLATE.md
@@ -41,7 +41,7 @@ Optional section that lists any concerns that should be resolved prior to implem
 
 ## Straw Poll
 
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). This PR must include a message + signature indicating ownership of a given amount of $AVAX.
+Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
 
 ### Supporters
 * `<message>/<signature>`

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -198,11 +198,11 @@ _This native approach is comparable to the idea of using $ETH to secure DA on [E
 
 * Any Subnet Validator running in "Partial Sync Mode" will not be able to verify Atomic Imports on the P-Chain and will rely entirely on Primary Network consensus to only accept valid P-Chain blocks.
 * High-throughput Subnets will be better isolated from the Primary Network and should improve its resilience (i.e. surges of traffic on some Subnet cannot destabilize a Primary Network Validator).
-* AvalancheGo must support tracking IPs for non-validators
+* Avalanche Network Clients (ANCs) must track IPs and provide allocated bandwidth for SOVs eventhough they are not Primary Network Validators.
 
 ## Open Questions
 
-* Bond amount?
+N/A
 
 ## Straw Poll
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -9,7 +9,7 @@ Track: Standards
 
 ## Abstract
 
-Introduce a new type of Subnet Validator that does not validate the Primary Network...
+Introduce a new type of Validator that is not required to validate the Primary Network...
 
 Remove the requirement that Subnet Validators must validate the Primary Network without revoking support for Subnet Validators to send/verify Avalanche Warp Messages (AWM). Allow Subnet Validators to stake on a Subnet by posting an $AVAX-deonimated bond.
 
@@ -21,11 +21,14 @@ Validators without restricting their ability to send or verify Avalanche Warp Me
 
 Each node operator must stake at least 2000 $AVAX (~$20k at the time of writing) to first become a Primary Network validator before they qualify to become a Subnet Validator. All Subnet Validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating.
 
+TODO: work in 2000 $AVAX here? 
 Although the fee paid to the Primary Network to operate a Subnet does not go up with the amount of activity on the Subnet, the fixed, upfront cost of setting up a Subnet Validator on the Primary Network deters new projects that prefer smaller, even variable, costs until demand is observed. _Unlike L2s that pay some increasing fee (usually denominated in units per transaction byte) to an external chain for data availability and security as activity scales, Subnets provide their own security/data availability and the only cost operators must pay from processing more activity is the hardware cost of supporting additional load._
 
 Regulated entities that are prohibited from validating permissionless, smart contract-enabled blockchains (like the C-Chain) can’t launch a Subnet because they can’t opt-out of Primary Network Validation. This deployment blocker prevents a large cohort of Real World Asset (RWA) issuers from bringing unique, valuable tokens to the Avalanche Ecosystem (that could move between C-Chain <> Subnets using AWM/Teleporter).
 
 TODO: fault isolation
+A popular Subnet ("popular" meaning validated by many nodes) could destabilitze the Primary Network if usage spikes unexpectedly (cause an OOM, disk IO, CPU exhaustion on a large number of Primary Network validators) or the inverse on the Primary Network (where some undefined behavior could bring a Subnet offline). Allowing optional separation IMO is a step in the right direction to making Primary Network/Subnets more resilient to regressions in the other.
+
 
 ## Specification
 
@@ -75,7 +78,37 @@ TODO
 
 #### Version
 
-Tracked Subnets?
+https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L93C1-L117C2
+
+Trscked Subnets?
+
+```text
+// Version is the first outbound message sent to a peer when a connection is
+// established to start the p2p handshake.
+//
+// Peers must respond to a Version message with a PeerList message to allow the
+// peer to connect to other peers in the network.
+//
+// Peers should drop connections to peers with incompatible versions.
+message Version {
+  // Network the peer is running on (e.g local, testnet, mainnet)
+  uint32 network_id = 1;
+  // Unix timestamp when this Version message was created
+  uint64 my_time = 2;
+  // IP address of the peer
+  bytes ip_addr = 3;
+  // IP port of the peer
+  uint32 ip_port = 4;
+  // Avalanche client version
+  string my_version = 5;
+  // Timestamp of the IP
+  uint64 my_version_time = 6;
+  // Signature of the peer IP port pair at a provided timestamp
+  bytes sig = 7;
+  // Subnets the peer is tracking
+  repeated bytes tracked_subnets = 8;
+}
+```
 
 #### GetPeers
 https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L135-L165
@@ -88,9 +121,36 @@ message GetPeers {
 ```
 
 #### -> PeerList
+https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L135-L148
+
+```text
+// PeerList contains network-level metadata for a set of validators.
+//
+// PeerList must be sent in response to an inbound Version message from a
+// remote peer a peer wants to connect to. Once a PeerList is received after
+// a version message, the p2p handshake is complete and the connection is
+// established.
+
+// Peers should periodically send PeerList messages to allow peers to
+// discover each other.
+//
+// PeerListAck should be sent in response to a PeerList.
+message PeerList {
+  repeated ClaimedIpPort claimed_ip_ports = 1;
+}
+```
 
 #### -> PeerListAck
+https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L160-L165
 
+```text
+// PeerListAck is sent in response to PeerList to acknowledge the subset of
+// peers that the peer will attempt to connect to.
+message PeerListAck {
+  reserved 1; // deprecated; used to be tx_ids
+  repeated PeerAck peer_acks = 2;
+}
+```
 
 ### Future Directions
 
@@ -101,24 +161,24 @@ Shared to (TODO: if not blocked by this, should share?)
 ...once relationship is decoupled, can consider 
 
 #### Pay-As-You-Go Subnet Validation Fees
+_To lower validation fees, should rely on BLS Multi-Singature Voting: https://hackmd.io/@patrickogrady/100k-subnets#How-will-BLS-Multi-Signature-uptime-voting-work_
 
-* Replace Proposal Block-based Subnet reward voting with BLS Multi-Signature votes from Subnet Validators
-* Transition Subnet Validation fees to a dynamically priced, continuously charged mechanism that doesn't require locking/staking large amounts of \$AVAX upfront _(this could be broken out as a separate step but makes sense to include in the voting code refactor, so kept here)_
+Transition Subnet Validation fees to a dynamically priced, continuously charged mechanism that doesn't require locking/staking large amounts of $AVAX upfront _(this could be broken out as a separate step but makes sense to include in the voting code refactor, so kept here)_
 
-To increase the P-Chain capacity for processing Subnet reward distributions (which should allow fees to be parameterized more aggressively), we first should replace Proposal Block-based voting (1 Subnet reward votes per block) with BLS Multi-Signature voting (N Subnet reward votes per block). _In a future state, this mechanism may allow Subnets to implement arbitrary reward mechanisms by adding an "amount" to this signed message instead of relying on the \$AVAX reward curve that is currently used by all Elastic Subnets. @stephenbuttolph has a number of ideas about this approach 👀._
-
-Once this vote processing change is implemented, it would be possible to just transition to a lower required "bond" amount, but many (myself included) think that it would be more competitve to transition to a dynamically priced, continuous payment mechanism. This new mechanism would target some $Y nAVAX fee that would be paid by each Subnet Validator per Subnet per second (pulling from a "Subnet Validator's Account") instead of requiring a large upfront lockup of \$AVAX.
+It would be possible to just transition to a lower required "bond" amount, but many (myself included) think that it would be more competitve to transition to a dynamically priced, continuous payment mechanism. This new mechanism would target some $Y nAVAX fee that would be paid by each Subnet Validator per Subnet per second (pulling from a "Subnet Validator's Account") instead of requiring a large upfront lockup of \$AVAX.
 
 _The rate of nAVAX/second should be set by the demand for validating Subnets on Avalanche compared to some usage target per Subnet and across all Subnets. This rate should be locked for each Subnet Validation period to ensure operators are not subject to suprise costs if demand rose significantly over time. All fees would still be paid to the network and burned, like all other P-Chain, X-Chain, and C-Chain transactions. The optimization work outlined here should allow the min rate to be set as low as ~512-4096 nAVAX/second (or 1.3-10.6 \$AVAX/month)._
 
 #### $AVAX-Augmented Subnet Security
+Some believe the relaxing of the validator relationship would be bad for $AVAX...
+
 
 * Enable unstaked \$AVAX to be locked to a Subnet Validator on an Elastic Subnet and slashed if said Subnet Validator commits an attributable fault (i.e. proposes/signs conflicting blocks/AWM payloads)
 * Reward locked \$AVAX associated with Subnet Validators that were not slashed with Elastic Subnet staking rewards
 
 Currently, the only way to secure an Elastic Subnet is to stake its staking token. Many have requested the option to use \$AVAX for this token, however, this could easily allow an adversary to takeover small Elastic Subnets (where the amount of \$AVAX staked may be much less than the circulating supply).
 
-\$AVAX-Augmented Subnet Security would allow anyone holding \$AVAX to lock it to specific Subnet Validators and earn Elastic Subnet reward tokens for supporting honest participants. Recall, all stake management on the Avalanche Network (even for Subnets) occurs on the P-Chain. Thus, staked tokens (\$AVAX and/or custom staking tokens used in Elastic Subnets) and stake weights (used for AWM verification) are secured by the full \\$AVAX stake of the Primary Network. \$AVAX-Augmented Subnet Security, like staking, would be implemented on the P-Chain and enjoy the full security of the Primary Network. This approach means locking \$AVAX occurs on the Primary Network (no need to transfer \$AVAX to a Subnet, which may not be secured by meaningful value yet) and proofs of malicious behavior are processed on the Primary Network (a colluding Subnet could otherwise chose not to process a proof that would lead to their "lockers" being slashed).
+\$AVAX-Augmented Subnet Security would allow anyone holding \$AVAX to lock it to specific Subnet Validators and earn Elastic Subnet reward tokens for supporting honest participants. Recall, all stake management on the Avalanche Network (even for Subnets) occurs on the P-Chain. Thus, staked tokens (\$AVAX and/or custom staking tokens used in Elastic Subnets) and stake weights (used for AWM verification) are secured by the full \$AVAX stake of the Primary Network. \$AVAX-Augmented Subnet Security, like staking, would be implemented on the P-Chain and enjoy the full security of the Primary Network. This approach means locking \$AVAX occurs on the Primary Network (no need to transfer \$AVAX to a Subnet, which may not be secured by meaningful value yet) and proofs of malicious behavior are processed on the Primary Network (a colluding Subnet could otherwise chose not to process a proof that would lead to their "lockers" being slashed).
 
 _This approach is comparable to the idea of using \$ETH to secure DA on [EigenLayer](https://www.eigenlayer.xyz/) (without reusing stake) or \$BTC to secure Cosmos Zones on [Babylon](https://babylonchain.io/) (but not using an external ecosystem)._
 
@@ -141,7 +201,6 @@ _This approach is comparable to the idea of using \$ETH to secure DA on [EigenLa
 ## Open Questions
 
 * Bond amount?
-* Use bloom filters for synchronizing peer lists
 
 ## Straw Poll
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -15,21 +15,17 @@ _This ACP does not modify/deprecate the existing Subnet Validation semantics for
 
 ## Motivation
 
-Each node operator must stake at least 2000 $AVAX (~$20k at the time of writing) to first become a Primary Network validator before they qualify to become a Subnet Validator. All Subnet Validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating. 
-
-TODO: work in 2000 $AVAX here? 
-Although the fee paid to the Primary Network to operate a Subnet does not go up with the amount of activity on the Subnet, the fixed, upfront cost of setting up a Subnet Validator on the Primary Network deters new projects that prefer smaller, even variable, costs until demand is observed. _Unlike L2s that pay some increasing fee (usually denominated in units per transaction byte) to an external chain for data availability and security as activity scales, Subnets provide their own security/data availability and the only cost operators must pay from processing more activity is the hardware cost of supporting additional load._
+Each node operator must stake at least 2000 $AVAX (~$20k at the time of writing) to first become a Primary Network validator before they qualify to become a Subnet Validator. Most Subnets aim to launch with at least 8 Subnet Validators, which requires staking 16000 $AVAX (~$160k at time of writing). All Subnet Validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating.
 
 Regulated entities that are prohibited from validating permissionless, smart contract-enabled blockchains (like the C-Chain) can’t launch a Subnet because they can’t opt-out of Primary Network Validation. This deployment blocker prevents a large cohort of Real World Asset (RWA) issuers from bringing unique, valuable tokens to the Avalanche Ecosystem (that could move between C-Chain <> Subnets using AWM/Teleporter).
 
-TODO: fault isolation
-A popular Subnet ("popular" meaning validated by many nodes) could destabilitze the Primary Network if usage spikes unexpectedly (cause an OOM, disk IO, CPU exhaustion on a large number of Primary Network validators) or the inverse on the Primary Network (where some undefined behavior could bring a Subnet offline). Allowing optional separation IMO is a step in the right direction to making Primary Network/Subnets more resilient to regressions in the other.
+Avalanche Warp Messaging (AWM), the native interoperability mechanism for the Avalanche Network, provides a way for Subnets to communicate with each other/C-Chain without a trusted intermediary. Any Subnet Validator must be able to register a BLS key and participate in AWM, otherwise a Subnet may not be able to generate a BLS Multi-Signature with sufficient participating stake.
 
-TODO: don't give up ability to use AWM
-Don't give up ability
+A widely validated Subnet could destabilitze the Primary Network if usage spikes unexpectedly. Underprovisioned Primary Network Validators running such a Subnet may exit with an OOM exception, see degraded disk performance, or be unable to allocate CPU time to P/X/C-Chain validation. The inverse also holds for Subnets with the Primary Network (where some undefined behavior could bring a Subnet offline).
+
+Although the fee paid to the Primary Network to operate a Subnet does not go up with the amount of activity on the Subnet, the fixed, upfront cost of setting up a Subnet Validator on the Primary Network deters new projects that prefer smaller, even variable, costs until demand is observed. _Unlike L2s that pay some increasing fee (usually denominated in units per transaction byte) to an external chain for data availability and security as activity scales, Subnets provide their own security/data availability and the only cost operators must pay from processing more activity is the hardware cost of supporting additional load._
 
 Elastic Subnets allow any community to weight Subnet Validation based on some staking token and reward Subnet Validators with high uptime with said staking token. However, there is no way for $AVAX holders on the Primary Network to augment the security of such Subnets.
-
 
 ## Specification
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -1,7 +1,7 @@
 ```text
 ACP: <TODO>
 Title: Subnet-Only Validators (SOVs)
-Author(s): Patrick O'Grady <patrickogrady.xyz>
+Author(s): Patrick O'Grady <contact@patrickogrady.xyz>
 Discussions-To: <TODO>
 Status: Proposed
 Track: Standards
@@ -17,11 +17,11 @@ _This ACP does not modify/deprecate the existing Subnet Validation semantics for
 
 Each node operator must stake at least 2000 $AVAX (~$20k at the time of writing) to first become a Primary Network validator before they qualify to become a Subnet Validator. Most Subnets aim to launch with at least 8 Subnet Validators, which requires staking 16000 $AVAX (~$160k at time of writing). All Subnet Validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating.
 
-Regulated entities that are prohibited from validating permissionless, smart contract-enabled blockchains (like the C-Chain) can’t launch a Subnet because they can’t opt-out of Primary Network Validation. This deployment blocker prevents a large cohort of Real World Asset (RWA) issuers from bringing unique, valuable tokens to the Avalanche Ecosystem (that could move between C-Chain <> Subnets using AWM/Teleporter).
-
 Avalanche Warp Messaging (AWM), the native interoperability mechanism for the Avalanche Network, provides a way for Subnets to communicate with each other/C-Chain without a trusted intermediary. Any Subnet Validator must be able to register a BLS key and participate in AWM, otherwise a Subnet may not be able to generate a BLS Multi-Signature with sufficient participating stake.
 
-A widely validated Subnet could destabilitze the Primary Network if usage spikes unexpectedly. Underprovisioned Primary Network Validators running such a Subnet may exit with an OOM exception, see degraded disk performance, or be unable to allocate CPU time to P/X/C-Chain validation. The inverse also holds for Subnets with the Primary Network (where some undefined behavior could bring a Subnet offline).
+Regulated entities that are prohibited from validating permissionless, smart contract-enabled blockchains (like the C-Chain) can’t launch a Subnet because they can’t opt-out of Primary Network Validation. This deployment blocker prevents a large cohort of Real World Asset (RWA) issuers from bringing unique, valuable tokens to the Avalanche Ecosystem (that could move between C-Chain <> Subnets using AWM/Teleporter).
+
+A widely validated Subnet that is not properly metered could destabilitze the Primary Network if usage spikes unexpectedly. Underprovisioned Primary Network Validators running such a Subnet may exit with an OOM exception, see degraded disk performance, or find it difficult to allocate CPU time to P/X/C-Chain validation. The inverse also holds for Subnets with the Primary Network (where some undefined behavior could bring a Subnet offline).
 
 Although the fee paid to the Primary Network to operate a Subnet does not go up with the amount of activity on the Subnet, the fixed, upfront cost of setting up a Subnet Validator on the Primary Network deters new projects that prefer smaller, even variable, costs until demand is observed. _Unlike L2s that pay some increasing fee (usually denominated in units per transaction byte) to an external chain for data availability and security as activity scales, Subnets provide their own security/data availability and the only cost operators must pay from processing more activity is the hardware cost of supporting additional load._
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -161,6 +161,11 @@ message PeerListAck {
 
 ### Future Work
 
+The previously described specification is a minimal, additive change to Subnet Validation semantics. It alone, however, fails to communicate what is possible if Subnet Validation is decoupled from Primary Network validation or provide an alternative use of $AVAX that would've otherwise been staked to create Subnet Validators.
+
+
+
+
 The following ideas require their own ACPs...
 
 Shared to (TODO: if not blocked by this, should share?)

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -107,88 +107,19 @@ type AddSubnetOnlyValidatorTx struct {
 
 _`AddSubnetOnlyValidatorTx` is almost the same as [`AddPermissionlessValidatorTx`](https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/vms/platformvm/txs/add_permissionless_validator_tx.go#L33-L58), the only exception being that `StakeOuts` are now `LockOuts`._
 
-### P2P
+### `GetSubnetPeers`
 
-To support tracking 
-
-#### Version
-
-https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L93C1-L117C2
-
-Trscked Subnets?
+To support tracking SOV IPs, a new message should be added to the P2P specification that allows Subnet Validators to request the IP of all peers a node knows about on a Subnet (these Signed IPs won't be gossiped like they are for Primary Network Validators because they don't need to be known by the entire Avalanche Network):
 
 ```text
-// Version is the first outbound message sent to a peer when a connection is
-// established to start the p2p handshake.
-//
-// Peers must respond to a Version message with a PeerList message to allow the
-// peer to connect to other peers in the network.
-//
-// Peers should drop connections to peers with incompatible versions.
-message Version {
-  // Network the peer is running on (e.g local, testnet, mainnet)
-  uint32 network_id = 1;
-  // Unix timestamp when this Version message was created
-  uint64 my_time = 2;
-  // IP address of the peer
-  bytes ip_addr = 3;
-  // IP port of the peer
-  uint32 ip_port = 4;
-  // Avalanche client version
-  string my_version = 5;
-  // Timestamp of the IP
-  uint64 my_version_time = 6;
-  // Signature of the peer IP port pair at a provided timestamp
-  bytes sig = 7;
-  // Subnets the peer is tracking
-  repeated bytes tracked_subnets = 8;
-}
-```
-
-#### GetPeers
-https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L135-L165
-
-```text
-// Return SubnetOnlyValidators?
-message GetPeers {
+message GetSubnetPeers {
     bytes subnet_id = 1;
 }
 ```
 
-#### -> PeerList
-https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L135-L148
+_It would be a nice addition if a bloom filter could also be provided here so that an ANC only sends IPs of peers that the original sender does not know._ 
 
-```text
-// PeerList contains network-level metadata for a set of validators.
-//
-// PeerList must be sent in response to an inbound Version message from a
-// remote peer a peer wants to connect to. Once a PeerList is received after
-// a version message, the p2p handshake is complete and the connection is
-// established.
-
-// Peers should periodically send PeerList messages to allow peers to
-// discover each other.
-//
-// PeerListAck should be sent in response to a PeerList.
-message PeerList {
-  repeated ClaimedIpPort claimed_ip_ports = 1;
-}
-```
-
-#### -> PeerListAck
-https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L160-L165
-
-```text
-// PeerListAck is sent in response to PeerList to acknowledge the subset of
-// peers that the peer will attempt to connect to.
-message PeerListAck {
-  reserved 1; // deprecated; used to be tx_ids
-  repeated PeerAck peer_acks = 2;
-}
-```
-
-
-`TODO` (will start once "Implementable")
+ANCs should respond to this incoming message with a [`PeerList` message](https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/proto/p2p/p2p.proto#L135-L148). 
 
 ## Security Considerations
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -216,7 +216,7 @@ Anyone can open a PR against an ACP and mark themselves as a supporter (you want
 
 ## Appendix
 
-A draft of this ACP was posted on in the ["Ideas" Discussion Board](https://github.com/avalanche-foundation/ACPs/discussions/10#discussioncomment-7373486), as suggested by the [ACP README](https://github.com/avalanche-foundation/ACPs#step-1-post-your-idea-to-github-discussions). Feedback on this draft was collected and responed to on both the "Ideas" Discussion Board and on [HackMD](https://hackmd.io/@patrickogrady/100k-subnets#Feedback-to-Draft-Proposal).
+A draft of this ACP was posted on in the ["Ideas" Discussion Board](https://github.com/avalanche-foundation/ACPs/discussions/10#discussioncomment-7373486), as suggested by the [ACP README](https://github.com/avalanche-foundation/ACPs#step-1-post-your-idea-to-github-discussions). Feedback on this draft was collected and addressed on both the "Ideas" Discussion Board and on [HackMD](https://hackmd.io/@patrickogrady/100k-subnets#Feedback-to-Draft-Proposal).
 
 ## Acknowledgements
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -161,16 +161,9 @@ message PeerListAck {
 
 ### Future Work
 
-The previously described specification is a minimal, additive change to Subnet Validation semantics. It alone, however, fails to communicate what is possible if Subnet Validation is decoupled from Primary Network validation or provide an alternative use of $AVAX that would've otherwise been staked to create Subnet Validators.
+The previously described specification is a minimal, additive change to Subnet Validation semantics that prepares the Avalanche Network for a more flexible Subnet model. It alone, however, fails to communicate this flexibility nor provides an alternative use of $AVAX that would have otherwise been used to create Subnet Validators.
 
-
-
-
-The following ideas require their own ACPs...
-
-Shared to (TODO: if not blocked by this, should share?)
-
-...once relationship is decoupled, can consider 
+Below are two high-level ideas (Pay-As-You-Go Subnet Validation Fees and $AVAX-Augmented Security) that highlight how this initial change could be extended in the future. If the Avalanche Community is interested in their adoption, they should each be proposed as a unique ACP where they can be properly specified. **These ideas are only suggestions for how the Avalanche Network could be modified in the future if this ACP is adopted. Supporting this ACP does not require supporting these ideas or committing to their rollout.**
 
 #### Pay-As-You-Go Subnet Validation Fees
 _To lower validation fees, should rely on BLS Multi-Singature Voting: https://hackmd.io/@patrickogrady/100k-subnets#How-will-BLS-Multi-Signature-uptime-voting-work_

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -187,12 +187,12 @@ _This native approach is comparable to the idea of using $ETH to secure DA on [E
 
 ## Backwards Compatibility
 
-* All existing Subnet Validators can continue validating both the Primary Network and whatever Subnets they are validating. This change would just provide a new option for Subnet Validators that allows them to sacrifice their staking rewards for a smaller upfront $AVAX commitment and lower infrastructure costs.
-* TODO: Support for this ACP would require adding a new transaction type to the P-Chain. This new transaction would not be compatible with Avalanche Cortina and require a mandatory Avalanche Network upgrade.
+* Existing Subnet Validation semantics for Primary Network Validators are not modified by this ACP. This means that All existing Subnet Validators can continue validating both the Primary Network and whatever Subnets they are validating. This change would just provide a new option for Subnet Validators that allows them to sacrifice their staking rewards for a smaller upfront $AVAX commitment and lower infrastructure costs.
+* Support for this ACP would require adding a new transaction type to the P-Chain (i.e. `AddSubnetOnlyValidatorTx`). This new transaction is an execution-breaking change that would require a mandatory Avalanche Network upgrade to activate.
 
 ## Reference Implementation
 
-`TODO` (once considered "Implementable")
+`TODO` (will start once "Implementable")
 
 ## Security Considerations
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -166,13 +166,14 @@ The previously described specification is a minimal, additive change to Subnet V
 Below are two high-level ideas (Pay-As-You-Go Subnet Validation Fees and $AVAX-Augmented Security) that highlight how this initial change could be extended in the future. If the Avalanche Community is interested in their adoption, they should each be proposed as a unique ACP where they can be properly specified. **These ideas are only suggestions for how the Avalanche Network could be modified in the future if this ACP is adopted. Supporting this ACP does not require supporting these ideas or committing to their rollout.**
 
 #### Pay-As-You-Go Subnet Validation Fees
-_To lower validation fees, should rely on BLS Multi-Singature Voting: https://hackmd.io/@patrickogrady/100k-subnets#How-will-BLS-Multi-Signature-uptime-voting-work_
 
-Transition Subnet Validation fees to a dynamically priced, continuously charged mechanism that doesn't require locking/staking large amounts of $AVAX upfront _(this could be broken out as a separate step but makes sense to include in the voting code refactor, so kept here)_
+**Idea:** Transition Subnet Validator registration to a dynamically priced, continuously charged fee (that doesn't require locking large amounts of $AVAX upfront)
 
-It would be possible to just transition to a lower required "bond" amount, but many (myself included) think that it would be more competitve to transition to a dynamically priced, continuous payment mechanism. This new mechanism would target some $Y nAVAX fee that would be paid by each Subnet Validator per Subnet per second (pulling from a "Subnet Validator's Account") instead of requiring a large upfront lockup of \$AVAX.
+While it would be possible to just transition to a lower required "lock" amount, many think that it would be more competitve to transition to a dynamically priced, continuous payment mechanism to register as a Subnet Validator. This new mechanism would target some $Y nAVAX fee that would be paid by each Subnet Validator per Subnet per second (pulling from a "Subnet Validator's Account") instead of requiring a large upfront lockup of $AVAX.
 
-_The rate of nAVAX/second should be set by the demand for validating Subnets on Avalanche compared to some usage target per Subnet and across all Subnets. This rate should be locked for each Subnet Validation period to ensure operators are not subject to suprise costs if demand rose significantly over time. All fees would still be paid to the network and burned, like all other P-Chain, X-Chain, and C-Chain transactions. The optimization work outlined here should allow the min rate to be set as low as ~512-4096 nAVAX/second (or 1.3-10.6 \$AVAX/month)._
+The rate of nAVAX/second should be set by the demand for validating Subnets on Avalanche compared to some usage target per Subnet and across all Subnets. This rate should be locked for each Subnet Validation period to ensure operators are not subject to suprise costs if demand rises significantly over time. The optimization work outlined in [BLS Multi-Signature Voting](https://hackmd.io/@patrickogrady/100k-subnets#How-will-BLS-Multi-Signature-uptime-voting-work) should allow the min rate to be set as low as ~512-4096 nAVAX/second (or 1.3-10.6 $AVAX/month).
+
+Fees paid to the Avalanche Network for PAYG could be burned, like all other P-Chain, X-Chain, and C-Chain transactions, or they could be partially rewarded to Primary Network Validators as a "boost" over the existing staking rewards. The nice byproduct of the latter approach is that it better aligns Primary Network Validators with the growth of Subnets.
 
 #### $AVAX-Augmented Subnet Security
 Some believe the relaxing of the validator relationship would be bad for $AVAX...

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -9,15 +9,7 @@ Track: Standards
 
 ## Abstract
 
-Introduce Subnet-Only Validators (SOVs), a new type of staker that can validate any Avalanche Subnet but is not required to validate the Primary Network. SOVs retain the ability to participate in Avalanche Warp Messaging (AWM) but do not need to sync the X/C-Chains must post an $AVAX-denominated bond...
-
-Introduce a new type of Validator that is not required to validate the Primary Network...
-
-Remove the requirement that Subnet Validators must validate the Primary Network without revoking support for Subnet Validators to send/verify Avalanche Warp Messages (AWM). Allow Subnet Validators to stake on a Subnet by posting an $AVAX-deonimated bond.
-
-and instead require bond...
-
-Validators without restricting their ability to send or verify Avalanche Warp Messages (AWM). Preview a future transition to Pay-As-You-Go Subnet Validation and $AVAX-Augmented Subnet Security.
+Introduce a new type of staker, Subnet-Only Validators (SOVs), that can validate an Avalanche Subnet and participate in Avalanche Warp Messaging (AWM) without syncing or becoming a Validator on the Primary Network. In lieu of staking at least 2000 $AVAX (minimum requirement to become a Primary Network Validator), a SOV locks 500 $AVAX on the P-Chain for the duration of their staking period. The semantics of Subnet Validation for Primary Network Validators are left unchanged.
 
 ## Motivation
 
@@ -47,6 +39,8 @@ Don't give up ability
   * https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/config/keys.go#L181-L188
   * https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/config/keys.go#L198-L203
 
+No rewards
+
 Without the requirement to validate the Primary Network, the need for Subnet Validators to instantiate and sync the C-Chain and X-Chain can be relaxed. Subnet Validators will only be required to sync the P-chain to track any validator set changes in their Subnet and to support Cross-Subnet communication via AWM (see “Primary Network Partial Sync” mode introduced in [Cortina 8](https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8)). The lower resource requirement in this "minimal mode" will provide Subnets with greater flexibility of validation hardware requirements as operators are not required to reserve any resources for C-Chain/X-Chain operation.
 
 _The value of the required "bond" (X) is open for debate. To avoid impacting network stability, I think it should be at least 250-750 \$AVAX. To set this "bond" lower, I think the PlatformVM should be futher optimized (assumes that lower fees lead to a corresponding increase in Subnets)._
@@ -56,6 +50,8 @@ _The value of the required "bond" (X) is open for debate. To avoid impacting net
 #### `AddSubnetOnlyValidatorTx`
 
 _This is the same as [`AddPermissionlessValidatorTx`](https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/vms/platformvm/txs/add_permissionless_validator_tx.go#L33-L58). The exception being that the minimum staked tokens are ...._
+
+TODO: change StakeOuts to LockOuts
 
 ```text
 type AddSubnetOnlyValidatorTx struct {

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -216,9 +216,7 @@ Anyone can open a PR against an ACP and mark themselves as a supporter (you want
 
 ## Appendix
 
-This ACP was previously posted as part of another discussion here: https://github.com/avalanche-foundation/ACPs/discussions/10#discussioncomment-7373486
-
-All feedback is here: https://hackmd.io/@patrickogrady/100k-subnets#Feedback-to-Draft-Proposal
+A draft of this ACP was posted on in the ["Ideas" Discussion Board](https://github.com/avalanche-foundation/ACPs/discussions/10#discussioncomment-7373486), as suggested by the [ACP README](https://github.com/avalanche-foundation/ACPs#step-1-post-your-idea-to-github-discussions). Feedback on this draft was collected and responed to on both the "Ideas" Discussion Board and on [HackMD](https://hackmd.io/@patrickogrady/100k-subnets#Feedback-to-Draft-Proposal).
 
 ## Acknowledgements
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -1,12 +1,10 @@
 ```text
-ACP: <PR Number>
-Title: <ACP title>
-Author(s): <a list of the author's name(s) and optionally contact info: FirstName LastName <foo@bar.com>>
-Discussions-To: <GitHub Discussion URL>
-Status: <Proposed, Implementable, Recommended, Stale>
-Track: <Standards, Best Practices, Meta>
-Replaces (*optional): <ACP number>
-Superseded-By (*optional): <ACP number>
+ACP: <TODO>
+Title: Subnet-Only Validators
+Author(s): Patrick O'Grady <patrickogrady.xyz>
+Discussions-To: <TODO>
+Status: Proposed
+Track: Standards
 ```
 
 This is the suggested template for new ACPs.
@@ -52,3 +50,4 @@ Anyone can open a PR against an ACP and mark themselves as a supporter (you want
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -9,6 +9,8 @@ Track: Standards
 
 ## Abstract
 
+Introduce Subnet-Only Validators (SOVs), a new type of staker that can validate any Avalanche Subnet but is not required to validate the Primary Network. SOVs retain the ability to participate in Avalanche Warp Messaging (AWM) but do not need to sync the X/C-Chains must post an $AVAX-denominated bond...
+
 Introduce a new type of Validator that is not required to validate the Primary Network...
 
 Remove the requirement that Subnet Validators must validate the Primary Network without revoking support for Subnet Validators to send/verify Avalanche Warp Messages (AWM). Allow Subnet Validators to stake on a Subnet by posting an $AVAX-deonimated bond.
@@ -29,20 +31,29 @@ Regulated entities that are prohibited from validating permissionless, smart con
 TODO: fault isolation
 A popular Subnet ("popular" meaning validated by many nodes) could destabilitze the Primary Network if usage spikes unexpectedly (cause an OOM, disk IO, CPU exhaustion on a large number of Primary Network validators) or the inverse on the Primary Network (where some undefined behavior could bring a Subnet offline). Allowing optional separation IMO is a step in the right direction to making Primary Network/Subnets more resilient to regressions in the other.
 
+TODO: don't give up ability to use AWM
+Don't give up ability
+
 
 ## Specification
+
+### Overview
 
 * Remove the requirement for a Subnet Validator to also be a Primary Network Validator but do not prevent it (current behavior not deprecated)
 * Introduce a new transaction type on the P-Chain for Subnet Validators that only want to validate a Subnet (`AddSubnetOnlyValidatorTx`)
 * Require Subnet-Only Validators to bond X $AVAX per validation per Subnet (to account for P-Chain Load)
 * Track IPs for Subnet-Only Validators in AvalancheGo to allow ....
-* Provide a guaranteed byte allotment for subnet validators
+* Provide a guaranteed RL allotment for subnet validators
+  * https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/config/keys.go#L181-L188
+  * https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/config/keys.go#L198-L203
 
 Without the requirement to validate the Primary Network, the need for Subnet Validators to instantiate and sync the C-Chain and X-Chain can be relaxed. Subnet Validators will only be required to sync the P-chain to track any validator set changes in their Subnet and to support Cross-Subnet communication via AWM (see “Primary Network Partial Sync” mode introduced in [Cortina 8](https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8)). The lower resource requirement in this "minimal mode" will provide Subnets with greater flexibility of validation hardware requirements as operators are not required to reserve any resources for C-Chain/X-Chain operation.
 
 _The value of the required "bond" (X) is open for debate. To avoid impacting network stability, I think it should be at least 250-750 \$AVAX. To set this "bond" lower, I think the PlatformVM should be futher optimized (assumes that lower fees lead to a corresponding increase in Subnets)._
 
-### `AddSubnetOnlyValidatorTx`
+### TODO
+
+#### `AddSubnetOnlyValidatorTx`
 
 _This is the same as [`AddPermissionlessValidatorTx`](https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/vms/platformvm/txs/add_permissionless_validator_tx.go#L33-L58). The exception being that the minimum staked tokens are ...._
 
@@ -152,7 +163,7 @@ message PeerListAck {
 }
 ```
 
-### Future Directions
+### Future Work
 
 The following ideas require their own ACPs...
 
@@ -186,7 +197,7 @@ _This approach is comparable to the idea of using \$ETH to secure DA on [EigenLa
 ## Backwards Compatibility
 
 * All existing Subnet Validators can continue validating both the Primary Network and whatever Subnets they are validating. This change would just provide a new option for Subnet Validators that allows them to sacrifice their staking rewards for a smaller upfront $AVAX commitment and lower infrastructure costs.
-* Support for Phase 1 would require adding a new transaction type to the P-Chain. This new transaction would not be compatible with Avalanche Cortina and require a mandatory Avalanche Network upgrade.
+* TODO: Support for this ACP would require adding a new transaction type to the P-Chain. This new transaction would not be compatible with Avalanche Cortina and require a mandatory Avalanche Network upgrade.
 
 ## Reference Implementation
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -9,7 +9,7 @@ Track: Standards
 
 ## Abstract
 
-Introduce a new type of staker, Subnet-Only Validators (SOVs), that can validate an Avalanche Subnet and participate in Avalanche Warp Messaging (AWM) without syncing or becoming a Validator on the Primary Network. Require SOVs to lock (not rewarded like existing staking) 500 $AVAX on the P-Chain for the duration of their staking period instead of staking at least 2000 $AVAX, the minimum requirement to become a Primary Network Validator. Preview a future transation to Pay-As-You-Go Subnet Validation and $AVAX-Augmented Subnet Security.
+Introduce a new type of staker, Subnet-Only Validators (SOVs), that can validate an Avalanche Subnet and participate in Avalanche Warp Messaging (AWM) without syncing or becoming a Validator on the Primary Network. Require SOVs to pay a refundable fee of 500 $AVAX on the P-Chain to register as a Subnet Validator instead of staking at least 2000 $AVAX, the minimum requirement to become a Primary Network Validator. Preview a future transation to Pay-As-You-Go Subnet Validation and $AVAX-Augmented Subnet Security.
 
 _This ACP does not modify/deprecate the existing Subnet Validation semantics for Primary Network Validators._
 
@@ -29,21 +29,17 @@ Elastic Subnets allow any community to weight Subnet Validation based on some st
 
 ## Specification
 
-### Overview
+### Required Changes
 
-* Remove the requirement for a Subnet Validator to also be a Primary Network Validator but do not prevent it (current behavior not deprecated)
-* Introduce a new transaction type on the P-Chain for Subnet Validators that only want to validate a Subnet (`AddSubnetOnlyValidatorTx`)
-* Require Subnet-Only Validators to bond X $AVAX per validation per Subnet (to account for P-Chain Load)
-* Track IPs for Subnet-Only Validators in AvalancheGo to allow ....
-* Provide a guaranteed RL allotment for subnet validators
-  * https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/config/keys.go#L181-L188
-  * https://github.com/ava-labs/avalanchego/blob/638000c42e5361e656ffbc27024026f6d8f67810/config/keys.go#L198-L203
+1) Introduce a new type of staker, Subnet-Only Validators (SOVs), that can validate an Avalanche Subnets and participate in Avalanche Warp Messaging (AWM) without syncing or becoming a Validator on the Primary Network
+2) Introduce a refundable fee (called a "lock") of 500 $AVAX that nodes must pay to become an SOV
+3) Introduce a non-refundable fee of 0.1 $AVAX that SOVs must pay to become an SOV
+4) Introduce a new transaction type on the P-Chain to register as an SOV (i.e. `AddSubnetOnlyValidatorTx`)
+5) Add a mode to ANCs that allows SOVs to optionally disable full Primary Network verification (only need to verify P-Chain)
+6) ANCs track IPs for SOVs to ensure Subnet Validators can find peers whether or not they are Primary Network Validators
+7) Provide a guaranteed rate limiting allowance for SOVs like Primary Network Validators
 
-No rewards
-
-Without the requirement to validate the Primary Network, the need for Subnet Validators to instantiate and sync the C-Chain and X-Chain can be relaxed. Subnet Validators will only be required to sync the P-chain to track any validator set changes in their Subnet and to support Cross-Subnet communication via AWM (see “Primary Network Partial Sync” mode introduced in [Cortina 8](https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8)). The lower resource requirement in this "minimal mode" will provide Subnets with greater flexibility of validation hardware requirements as operators are not required to reserve any resources for C-Chain/X-Chain operation.
-
-_The value of the required "bond" (X) is open for debate. To avoid impacting network stability, I think it should be at least 250-750 \$AVAX. To set this "bond" lower, I think the PlatformVM should be futher optimized (assumes that lower fees lead to a corresponding increase in Subnets)._
+Because SOVs do not validate the Primary Network, they will not be rewarded with $AVAX for "locking" the 500 $AVAX required to become an SOV. This enables people interested in validating Subnets to opt for a lower upfront $AVAX commitment and lower infrastructure costs instead of $AVAX rewards. Additionally, SOVs will only be required to sync the P-chain (not X/C-Chain) to track any validator set changes in their Subnet and to support Cross-Subnet communication via AWM (see “Primary Network Partial Sync” mode introduced in [Cortina 8](https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8)). The lower resource requirement in this "minimal mode" will provide Subnets with greater flexibility of validation hardware requirements as operators are not required to reserve any resources for C-Chain/X-Chain operation. If an SOV wishes to sync the entire Primary Network, they still can.
 
 ### TODO
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -167,7 +167,7 @@ Below are two high-level ideas (Pay-As-You-Go Subnet Validation Fees and $AVAX-A
 
 #### Pay-As-You-Go Subnet Validation Fees
 
-**Idea:** Transition Subnet Validator registration to a dynamically priced, continuously charged fee (that doesn't require locking large amounts of $AVAX upfront)
+_Transition Subnet Validator registration to a dynamically priced, continuously charged fee (that doesn't require locking large amounts of $AVAX upfront)._
 
 While it would be possible to just transition to a lower required "lock" amount, many think that it would be more competitve to transition to a dynamically priced, continuous payment mechanism to register as a Subnet Validator. This new mechanism would target some $Y nAVAX fee that would be paid by each Subnet Validator per Subnet per second (pulling from a "Subnet Validator's Account") instead of requiring a large upfront lockup of $AVAX.
 
@@ -176,18 +176,14 @@ The rate of nAVAX/second should be set by the demand for validating Subnets on A
 Fees paid to the Avalanche Network for PAYG could be burned, like all other P-Chain, X-Chain, and C-Chain transactions, or they could be partially rewarded to Primary Network Validators as a "boost" over the existing staking rewards. The nice byproduct of the latter approach is that it better aligns Primary Network Validators with the growth of Subnets.
 
 #### $AVAX-Augmented Subnet Security
-Some believe the relaxing of the validator relationship would be bad for $AVAX...
 
+_Allow pledging unstaked $AVAX to Subnet Validators on Elastic Subnets that can be slashed if said Subnet Validator commits an attributable fault (i.e. proposes/signs conflicting blocks/AWM payloads). Reward locked $AVAX associated with Subnet Validators that were not slashed with Elastic Subnet staking rewards._
 
-* Enable unstaked \$AVAX to be locked to a Subnet Validator on an Elastic Subnet and slashed if said Subnet Validator commits an attributable fault (i.e. proposes/signs conflicting blocks/AWM payloads)
-* Reward locked \$AVAX associated with Subnet Validators that were not slashed with Elastic Subnet staking rewards
+Currently, the only way to secure an Elastic Subnet is to stake its custom staking token (defined in the `TransformSubnetTx`). Many have requested the option to use $AVAX for this token, however, this could easily allow an adversary to takeover small Elastic Subnets (where the amount of $AVAX staked may be much less than the circulating supply).
 
-Currently, the only way to secure an Elastic Subnet is to stake its staking token. Many have requested the option to use \$AVAX for this token, however, this could easily allow an adversary to takeover small Elastic Subnets (where the amount of \$AVAX staked may be much less than the circulating supply).
+$AVAX-Augmented Subnet Security would allow anyone holding $AVAX to lock it to specific Subnet Validators and earn Elastic Subnet reward tokens for supporting honest participants. Recall, all stake management on the Avalanche Network (even for Subnets) occurs on the P-Chain. Thus, staked tokens ($AVAX and/or custom staking tokens used in Elastic Subnets) and stake weights (used for AWM verification) are secured by the full $AVAX stake of the Primary Network. $AVAX-Augmented Subnet Security, like staking, would be implemented on the P-Chain and enjoy the full security of the Primary Network. This approach means locking $AVAX occurs on the Primary Network (no need to transfer $AVAX to a Subnet, which may not be secured by meaningful value yet) and proofs of malicious behavior are processed on the Primary Network (a colluding Subnet could otherwise chose not to process a proof that would lead to their "lockers" being slashed).
 
-\$AVAX-Augmented Subnet Security would allow anyone holding \$AVAX to lock it to specific Subnet Validators and earn Elastic Subnet reward tokens for supporting honest participants. Recall, all stake management on the Avalanche Network (even for Subnets) occurs on the P-Chain. Thus, staked tokens (\$AVAX and/or custom staking tokens used in Elastic Subnets) and stake weights (used for AWM verification) are secured by the full \$AVAX stake of the Primary Network. \$AVAX-Augmented Subnet Security, like staking, would be implemented on the P-Chain and enjoy the full security of the Primary Network. This approach means locking \$AVAX occurs on the Primary Network (no need to transfer \$AVAX to a Subnet, which may not be secured by meaningful value yet) and proofs of malicious behavior are processed on the Primary Network (a colluding Subnet could otherwise chose not to process a proof that would lead to their "lockers" being slashed).
-
-_This approach is comparable to the idea of using \$ETH to secure DA on [EigenLayer](https://www.eigenlayer.xyz/) (without reusing stake) or \$BTC to secure Cosmos Zones on [Babylon](https://babylonchain.io/) (but not using an external ecosystem)._
-
+_This native approach is comparable to the idea of using $ETH to secure DA on [EigenLayer](https://www.eigenlayer.xyz/) (without reusing stake) or $BTC to secure Cosmos Zones on [Babylon](https://babylonchain.io/) (but not using an external ecosystem)._
 
 ## Backwards Compatibility
 

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -9,11 +9,13 @@ Track: Standards
 
 ## Abstract
 
-Introduce a new type of staker, Subnet-Only Validators (SOVs), that can validate an Avalanche Subnet and participate in Avalanche Warp Messaging (AWM) without syncing or becoming a Validator on the Primary Network. In lieu of staking at least 2000 $AVAX (minimum requirement to become a Primary Network Validator), a SOV locks 500 $AVAX on the P-Chain for the duration of their staking period. The semantics of Subnet Validation for Primary Network Validators are left unchanged.
+Introduce a new type of staker, Subnet-Only Validators (SOVs), that can validate an Avalanche Subnet and participate in Avalanche Warp Messaging (AWM) without syncing or becoming a Validator on the Primary Network. Require SOVs to lock (not rewarded like existing staking) 500 $AVAX on the P-Chain for the duration of their staking period instead of staking at least 2000 $AVAX, the minimum requirement to become a Primary Network Validator. Preview a future transation to Pay-As-You-Go Subnet Validation and $AVAX-Augmented Subnet Security.
+
+_This ACP does not modify/deprecate the existing Subnet Validation semantics for Primary Network Validators._
 
 ## Motivation
 
-Each node operator must stake at least 2000 $AVAX (~$20k at the time of writing) to first become a Primary Network validator before they qualify to become a Subnet Validator. All Subnet Validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating.
+Each node operator must stake at least 2000 $AVAX (~$20k at the time of writing) to first become a Primary Network validator before they qualify to become a Subnet Validator. All Subnet Validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating. 
 
 TODO: work in 2000 $AVAX here? 
 Although the fee paid to the Primary Network to operate a Subnet does not go up with the amount of activity on the Subnet, the fixed, upfront cost of setting up a Subnet Validator on the Primary Network deters new projects that prefer smaller, even variable, costs until demand is observed. _Unlike L2s that pay some increasing fee (usually denominated in units per transaction byte) to an external chain for data availability and security as activity scales, Subnets provide their own security/data availability and the only cost operators must pay from processing more activity is the hardware cost of supporting additional load._
@@ -25,6 +27,8 @@ A popular Subnet ("popular" meaning validated by many nodes) could destabilitze 
 
 TODO: don't give up ability to use AWM
 Don't give up ability
+
+Elastic Subnets allow any community to weight Subnet Validation based on some staking token and reward Subnet Validators with high uptime with said staking token. However, there is no way for $AVAX holders on the Primary Network to augment the security of such Subnets.
 
 
 ## Specification

--- a/ACPs/X-subnet-only-validators.md
+++ b/ACPs/X-subnet-only-validators.md
@@ -7,39 +7,77 @@ Status: Proposed
 Track: Standards
 ```
 
-This is the suggested template for new ACPs.
-
 ## Abstract
 
-A concise (~200 word) description of the ACP being proposed. This should be a very clear and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this ACP is about.
+Remove the requirement that Subnet Validators must validate the Primary Network and instead require bond...
+
+Validators without restricting their ability to send or verify Avalanche Warp Messages (AWM). Preview a future transition to Pay-As-You-Go Subnet Validation and $AVAX-Augmented Subnet Security.
 
 ## Motivation
 
-The motivation is critical for ACPs that want to change the functionality of the Avalanche Network. It should clearly explain why the existing Avalanche Network implementation is inadequate to address the problem that the ACP solves.
+Each node operator must stake at least 2000 $AVAX (~$20k at the time of writing) to first become a Primary Network validator before they qualify to become a Subnet Validator. All Subnet Validators, to satisfy their role as Primary Network Validators, must also allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating.
+
+Although the fee paid to the Primary Network to operate a Subnet does not go up with the amount of activity on the Subnet, the fixed, upfront cost of setting up a Subnet Validator on the Primary Network deters new projects that prefer smaller, even variable, costs until demand is observed. _Unlike L2s that pay some increasing fee (usually denominated in units per transaction byte) to an external chain for data availability and security as activity scales, Subnets provide their own security/data availability and the only cost operators must pay from processing more activity is the hardware cost of supporting additional load._
+
+Regulated entities that are prohibited from validating permissionless, smart contract-enabled blockchains (like the C-Chain) can’t launch a Subnet because they can’t opt-out of Primary Network Validation. This deployment blocker prevents a large cohort of Real World Asset (RWA) issuers from bringing unique, valuable tokens to the Avalanche Ecosystem (that could move between C-Chain <> Subnets using AWM/Teleporter).
+
+TODO: fault isolation
 
 ## Specification
 
-The technical specification should describe the syntax and semantics of any ACP. The specification should be detailed enough to allow any Avalanche Network Client (ANC) to implement the ACP without consultation from the author(s).
+* Remove the requirement for a Subnet Validator to also be a Primary Network Validator but do not prevent it (current behavior not deprecated)
+* Introduce a new transaction type on the P-Chain for Subnet Validators that only want to validate a Subnet (`AddSubnetOnlyValidatorTx`)
+* Require Subnet-Only Validators to bond X \$AVAX per validation per Subnet (to account for P-Chain Load)
+
+Without the requirement to validate the Primary Network, the need for Subnet Validators to instantiate and sync the C-Chain and X-Chain can be relaxed. Subnet Validators will only be required to sync the P-chain to track any validator set changes in their Subnet and to support Cross-Subnet communication via AWM (see “Primary Network Partial Sync” mode introduced in [Cortina 8](https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8)). The lower resource requirement in this "minimal mode" will provide Subnets with greater flexibility of validation hardware requirements as operators are not required to reserve any resources for C-Chain/X-Chain operation.
+
+_The value of the required "bond" (X) is open for debate. To avoid impacting network stability, I think it should be at least 250-750 \$AVAX. To set this "bond" lower, I think the PlatformVM should be futher optimized (assumes that lower fees lead to a corresponding increase in Subnets)._
+
+### Future Directions
+#### Improve PlatformVM Efficiency + Pay-As-You-Go Subnet Validation Fees
+
+* Replace Proposal Block-based Subnet reward voting with BLS Multi-Signature votes from Subnet Validators
+* Transition Subnet Validation fees to a dynamically priced, continuously charged mechanism that doesn't require locking/staking large amounts of \$AVAX upfront _(this could be broken out as a separate step but makes sense to include in the voting code refactor, so kept here)_
+
+To increase the P-Chain capacity for processing Subnet reward distributions (which should allow fees to be parameterized more aggressively), we first should replace Proposal Block-based voting (1 Subnet reward votes per block) with BLS Multi-Signature voting (N Subnet reward votes per block). _In a future state, this mechanism may allow Subnets to implement arbitrary reward mechanisms by adding an "amount" to this signed message instead of relying on the \$AVAX reward curve that is currently used by all Elastic Subnets. @stephenbuttolph has a number of ideas about this approach 👀._
+
+Once this vote processing change is implemented, it would be possible to just transition to a lower required "bond" amount, but many (myself included) think that it would be more competitve to transition to a dynamically priced, continuous payment mechanism. This new mechanism would target some $Y nAVAX fee that would be paid by each Subnet Validator per Subnet per second (pulling from a "Subnet Validator's Account") instead of requiring a large upfront lockup of \$AVAX.
+
+_The rate of nAVAX/second should be set by the demand for validating Subnets on Avalanche compared to some usage target per Subnet and across all Subnets. This rate should be locked for each Subnet Validation period to ensure operators are not subject to suprise costs if demand rose significantly over time. All fees would still be paid to the network and burned, like all other P-Chain, X-Chain, and C-Chain transactions. The optimization work outlined here should allow the min rate to be set as low as ~512-4096 nAVAX/second (or 1.3-10.6 \$AVAX/month)._
+
+#### $AVAX-Augmented Subnet Security
+
+* Enable unstaked \$AVAX to be locked to a Subnet Validator on an Elastic Subnet and slashed if said Subnet Validator commits an attributable fault (i.e. proposes/signs conflicting blocks/AWM payloads)
+* Reward locked \$AVAX associated with Subnet Validators that were not slashed with Elastic Subnet staking rewards
+
+Currently, the only way to secure an Elastic Subnet is to stake its staking token. Many have requested the option to use \$AVAX for this token, however, this could easily allow an adversary to takeover small Elastic Subnets (where the amount of \$AVAX staked may be much less than the circulating supply).
+
+\$AVAX-Augmented Subnet Security would allow anyone holding \$AVAX to lock it to specific Subnet Validators and earn Elastic Subnet reward tokens for supporting honest participants. Recall, all stake management on the Avalanche Network (even for Subnets) occurs on the P-Chain. Thus, staked tokens (\$AVAX and/or custom staking tokens used in Elastic Subnets) and stake weights (used for AWM verification) are secured by the full \\$AVAX stake of the Primary Network. \$AVAX-Augmented Subnet Security, like staking, would be implemented on the P-Chain and enjoy the full security of the Primary Network. This approach means locking \$AVAX occurs on the Primary Network (no need to transfer \$AVAX to a Subnet, which may not be secured by meaningful value yet) and proofs of malicious behavior are processed on the Primary Network (a colluding Subnet could otherwise chose not to process a proof that would lead to their "lockers" being slashed).
+
+_This approach is comparable to the idea of using \$ETH to secure DA on [EigenLayer](https://www.eigenlayer.xyz/) (without reusing stake) or \$BTC to secure Cosmos Zones on [Babylon](https://babylonchain.io/) (but not using an external ecosystem)._
+
 
 ## Backwards Compatibility
 
-All ACPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The ACP should provide recommendations for dealing with these incompatibilities.
+* All existing Subnet Validators can continue validating both the Primary Network and whatever Subnets they are validating. This change would just provide a new option for Subnet Validators that allows them to sacrifice their staking rewards for a smaller upfront $AVAX commitment and lower infrastructure costs.
+* Support for Phase 1 would require adding a new transaction type to the P-Chain. This new transaction would not be compatible with Avalanche Cortina and require a mandatory Avalanche Network upgrade.
 
 ## Reference Implementation
 
-A reference/example implementation that people can use to assist in understanding or implementing this specification. If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `./ACP-####-implementation/*` or linking to a PR on an external repository.
+`TODO` (once considered "Implementable")
 
 ## Security Considerations
 
-Optional section that discusses the security implications/considerations relevant to the proposed change.
+* Any Subnet Validator running in "Partial Sync Mode" will not be able to verify Atomic Imports on the P-Chain and will rely entirely on Primary Network consensus to only accept valid P-Chain blocks.
+* High-throughput Subnets will be better isolated from the Primary Network and should improve its resilience (i.e. surges of traffic on some Subnet cannot destabilize a Primary Network Validator).
 
 ## Open Questions
 
-Optional section that lists any concerns that should be resolved prior to implementation.
+* Bond amount?
 
 ## Straw Poll
 
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). This PR must include a message + signature indicating ownership of a given amount of $AVAX.
+Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
 
 ### Supporters
 * `<message>/<signature>`


### PR DESCRIPTION
Introduce a new type of staker, Subnet-Only Validators (SOVs), that can validate an Avalanche Subnet and participate in Avalanche Warp Messaging (AWM) without syncing or becoming a Validator on the Primary Network. Require SOVs to pay a refundable fee of 500 $AVAX on the P-Chain to register as a Subnet Validator instead of staking at least 2000 $AVAX, the minimum requirement to become a Primary Network Validator. Preview a future transation to Pay-As-You-Go Subnet Validation and $AVAX-Augmented Subnet Security.

_This ACP does not modify/deprecate the existing Subnet Validation semantics for Primary Network Validators._