### PR TITLE
ACP-20: Change recommended ed25519 lib

### DIFF
--- a/ACPs/20-ed25519-p2p.md
+++ b/ACPs/20-ed25519-p2p.md
@@ -69,9 +69,9 @@ From [Chalkias et al. 2020](https://eprint.iacr.org/2020/1244.pdf):
 * The RFC 8032 and the NIST FIPS186-5 draft both require to reject non-canonically encoded points, but not all of the implementations follow those guidelines.
 * The RFC 8032 allows optionality between using a permissive verification equation and a more strict verification equation. Different implementations use different equations meaning validation results can vary even across implementations that follow RFC 8032.
 
-Zcash adopted [ZIP-215](https://zips.z.cash/zip-0215) (proposed by Henry de Valance) to explicitly define the Ed25519 validation criteria. Implementers of this ACP should use the ZIP-215 validation criteria.
+Zcash adopted [ZIP-215](https://zips.z.cash/zip-0215) (proposed by Henry de Valance) to explicitly define the Ed25519 validation criteria. Implementers of this ACP _*must*_ use the ZIP-215 validation criteria.
 
-The [`crypto25519-voi`](https://github.com/oasisprotocol/curve25519-voi) golang library contains an implementation of Ed25519 that follows ZIP-215. This library is also used by the [HyperSDK](https://github.com/ava-labs/hypersdk/blob/main/crypto/ed25519/ed25519.go).
+The [`ed25519consensus`](https://github.com/hdevalence/ed25519consensus) golang library is a minimal fork of golang's `crypto/ed25519` package with support for ZIP-215 verification. It is maintained by [Filippo Valsorda](https://github.com/FiloSottile) who also maintains many golang stdlib cryptography packages. It is strongly recommended to use this library for golang implementations.
 
 ## Open Questions
 


### PR DESCRIPTION
This PR updates the proposal to recommend https://github.com/hdevalence/ed25519consensus and require ZIP-215 verification.

https://github.com/oasisprotocol/curve25519-voi is a complete reimplementation of ed25519. https://github.com/hdevalence/ed25519consensus relies on the stdlib `crypto/ed25519` and is a small modification on top of that. Additionally, https://github.com/hdevalence/ed25519consensus also supports batch verification. 