### PR TITLE
Mark ACP-24 (Shanghai EIPs) implementable

### DIFF
--- a/ACPs/24-shanghai-eips.md
+++ b/ACPs/24-shanghai-eips.md
@@ -3,7 +3,7 @@ ACP: 24
 Title: Activate Shanghai EIPs on C-Chain
 Author(s): Darioush Jalali <https://github.com/darioush>
 Discussions-To: https://github.com/avalanche-foundation/ACPs/discussions/27
-Status: Proposed
+Status: Implementable
 Track: Standards
 ```
 


### PR DESCRIPTION
This PR marks ACP-24 as implementable.