### PR TITLE
ACP-30: update gas cost to account for 3 log topics in SendWarpMessage

### DIFF
--- a/ACPs/30-avalanche-warp-x-evm.md
+++ b/ACPs/30-avalanche-warp-x-evm.md
@@ -140,12 +140,12 @@ The execution gas costs were determined by summing the cost of the EVM operation
 
 ##### sendWarpMessage
 
-`sendWarpMessage` charges a base cost of 41,875 gas
+`sendWarpMessage` charges a base cost of 41,500 gas
 
 This is comprised of charging for the following components:
 
 - 375 gas / log operation
-- 4 topics * 375 gas / topic
+- 3 topics * 375 gas / topic
 - 20k gas to produce and serve a BLS Signature
 - 20k gas to store the Unsigned Warp Message
 


### PR DESCRIPTION
This PR updates the `SendWarpMessageGasCost` to `3*params.LogTopicGas` to reflect that there are now three topics emitted instead of 4.

This was changed in https://github.com/ava-labs/subnet-evm/pull/923/files to remove the `destinationChainID` and `destinationAddress` fields from the warp message type as a result of this discussion: https://github.com/ava-labs/avalanchego/discussions/2050.