### PR TITLE
Remove ACP Straw Polls

### DIFF
--- a/ACPs/13-subnet-only-validators.md
+++ b/ACPs/13-subnet-only-validators.md
@@ -131,16 +131,6 @@ ANCs should respond to this incoming message with a [`PeerList` message](https:/
 
 * To help orient the Avalanche Community around this wide-ranging and likely to be long-running conversation around the relationship between the Primary Network and Subnets, should we come up with a project name to describe the effort? I've been casually referring to all of these things as the _Astra Upgrade Track_ but definitely up for discussion (may be more confusing than it is worth to do this).
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Appendix
 
 A draft of this ACP was posted on in the ["Ideas" Discussion Board](https://github.com/avalanche-foundation/ACPs/discussions/10#discussioncomment-7373486), as suggested by the [ACP README](https://github.com/avalanche-foundation/ACPs#step-1-post-your-idea-to-github-discussions). Feedback on this draft was collected and addressed on both the "Ideas" Discussion Board and on [HackMD](https://hackmd.io/@patrickogrady/100k-subnets#Feedback-to-Draft-Proposal).

--- a/ACPs/20-ed25519-p2p.md
+++ b/ACPs/20-ed25519-p2p.md
@@ -83,16 +83,6 @@ _Can this Ed25519 key be used for Verifiable Random Functions?_
 
 Yes. VRFs, as specified in [RFC9381](https://datatracker.ietf.org/doc/html/rfc9381), can be constructed using elliptic curves that are secure in the cryptographic random oracle model. Ed25519 test vectors are provided in the RFC for implementers of an Elliptic Curve VRF (ECVRF). This allows for Avalanche validators to generate a VRF per block using their associated Ed25519 keys, including for Subnets.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Acknowledgements
 
 Thanks to [@StephenButtolph](https://github.com/StephenButtolph) and [@patrick-ogrady](https://github.com/patrick-ogrady) for their feedback on these ideas.

--- a/ACPs/23-p-chain-native-transfers.md
+++ b/ACPs/23-p-chain-native-transfers.md
@@ -41,16 +41,6 @@ The P-chain has fixed fees which does not place any limits on chain throughput. 
 
 No open questions.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Acknowledgements
 
 Thanks to [@StephenButtolph](https://github.com/StephenButtolph) and [@abi87](https://github.com/abi87) for their feedback on the reference implementation.

--- a/ACPs/24-shanghai-eips.md
+++ b/ACPs/24-shanghai-eips.md
@@ -47,16 +47,6 @@ Refer to the original EIPs for security considerations:
 
 No open questions.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ACPs/25-vm-application-errors.md
+++ b/ACPs/25-vm-application-errors.md
@@ -69,16 +69,6 @@ Clients should be aware that peers can arbitrarily send `AppError` messages to i
 
 Optional section that lists any concerns that should be resolved prior to implementation.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). This PR must include a message + signature indicating ownership of a given amount of $AVAX.
-
-### Supporters
-                                                                                                                                                                                                                                                                      * `<message>/<signature>`
-
-### Objectors
-                                                                                                                                                                                                                                                                      * `<message>/<signature>`
-
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ACPs/30-avalanche-warp-x-evm.md
+++ b/ACPs/30-avalanche-warp-x-evm.md
@@ -198,16 +198,6 @@ The verification cost of performing a validator set lookup on the P-Chain is cur
 
 [Ongoing work](https://github.com/ava-labs/avalanchego/pull/1611) can parallelize P-Chain validator set lookups and message verification to reduce the impact on block verification latency to be negligible and reduce costs to reflect the additional bandwidth of encoding Avalanche Warp Messages in the transaction.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Acknowledgements
 
 Avalanche Warp Messaging and this effort to integrate it into the EVM has been a monumental effort. Thanks to all of the contributors who contributed their ideas, feedback, and development to this effort.

--- a/ACPs/31-enable-subnet-ownership-transfer.md
+++ b/ACPs/31-enable-subnet-ownership-transfer.md
@@ -59,16 +59,6 @@ No security considerations.
 
 No open questions.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Acknowledgements
 
 Thank you [@friskyfoxdk](https://github.com/friskyfoxdk) for filing an [issue](https://github.com/ava-labs/avalanchego/issues/1946) requesting this feature. Thanks to [@StephenButtolph](https://github.com/StephenButtolph) and [@abi87](https://github.com/abi87) for their feedback on the reference implementation.

--- a/ACPs/41-remove-pending-stakers.md
+++ b/ACPs/41-remove-pending-stakers.md
@@ -50,16 +50,6 @@ As mentioned above, the beginning of your staking period is the block acceptance
 
 Delegators can maximize their staking period by setting the same `EndTime` as the Validator they are delegating to.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Acknowledgements
 
 Thanks to [@StephenButtolph](https://github.com/StephenButtolph) and [@abi87](https://github.com/abi87) for their feedback on these ideas.

--- a/ACPs/62-disable-addvalidatortx-and-adddelegatortx.md
+++ b/ACPs/62-disable-addvalidatortx-and-adddelegatortx.md
@@ -52,16 +52,6 @@ No security considerations.
 
 ## Open Questions
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Acknowledgements
 
 Thanks to [@StephenButtolph](https://github.com/StephenButtolph) and [@patrick-ogrady](https://github.com/patrick-ogrady) for their feedback on these ideas.

--- a/ACPs/TEMPLATE.md
+++ b/ACPs/TEMPLATE.md
@@ -39,16 +39,6 @@ Optional section that discusses the security implications/considerations relevan
 
 Optional section that lists any concerns that should be resolved prior to implementation.
 
-## Straw Poll
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). [This PR must include a message + signature indicating ownership of a given amount of $AVAX](https://github.com/avalanche-foundation/ACPs#acp-straw-poll).
-
-### Supporters
-* `<message>/<signature>`
-
-### Objectors
-* `<message>/<signature>`
-
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Once the author(s) feels confident that an idea has a decent chance of acceptanc
 
 ### Step 3: Build Consensus on [GitHub Discussions](https://github.com/avalanche-foundation/ACPs/discussions/categories/discussion) and Provide an Implementation (if Applicable)
 
-ACPs will be merged by ACP maintainers if the proposal is generally well-formatted and coherent. ACP editors will attempt to merge anything worthy of discussion, regardless of feasibility or complexity, that is not a duplicate or incomplete. After an ACP is merged, an official GitHub Discussion will be opened for the ACP and linked to the proposal for community discussion. It is recommended for author(s) or supportive Avalanche Community members to post an accompanying non-technical overview of their ACP for general consumption in this GitHub Discussion. The ACP should be reviewed and broadly supported before a reference implementation is started, again to avoid wasting the author(s) and the Avalanche Community's time, unless a reference implementation will aid people in studying the ACP. At any point in time, Avalanche Community members can sign a message indicating their support/objection to the ACP in the "Straw Poll".
+ACPs will be merged by ACP maintainers if the proposal is generally well-formatted and coherent. ACP editors will attempt to merge anything worthy of discussion, regardless of feasibility or complexity, that is not a duplicate or incomplete. After an ACP is merged, an official GitHub Discussion will be opened for the ACP and linked to the proposal for community discussion. It is recommended for author(s) or supportive Avalanche Community members to post an accompanying non-technical overview of their ACP for general consumption in this GitHub Discussion. The ACP should be reviewed and broadly supported before a reference implementation is started, again to avoid wasting the author(s) and the Avalanche Community's time, unless a reference implementation will aid people in studying the ACP.
 
 ### Step 4: Mark ACP as `Implementable` via [Pull Request](https://github.com/avalanche-foundation/ACPs/pulls)
 
@@ -64,7 +64,6 @@ Each ACP must have the following parts:
 Each ACP can have the following parts:
 
 * `Open Questions`: Questions that should be resolved before implementation
-* `Straw Poll`: Collection of advocates/objectors of an ACP
 
 Each `Standards Track` ACP must have the following parts:
 
@@ -75,28 +74,6 @@ Each `Best Practices Track` ACP can have the following parts:
 
 * `Backwards Compatibility`: List of backwards incompatible changes required to implement the ACP and their impact on the Avalanche Community
 * `Reference Implementation`: Code, documentation, and telemetry (from a local network) of the ACP change
-
-### ACP "Straw Poll"
-
-Anyone can open a PR against an ACP and mark themselves as a supporter (you want an ACP to be adopted) or as an objector (you want the ACP to be rejected). This PR must include a message + signature indicating ownership of a given amount of $AVAX. This action is non-binding and only meant to gauge support of an ACP in the Avalanche Community.
-
-If you wish to do this, please sign the following payload on the [Avalanche Wallet](https://wallet.avax.network/wallet/advanced):
-
-```text
-AVALANCHE_STRAW_POLL|<ACP Number>|<yes/no>|<timestamp (unix time)>|<metadata (optional)>
-```
-
-Here is an example:
-
-```text
-Address: "P-avax12xnpg0ecyvc70xqqf9ellc7kqlxpvtmt30ezzy"
-Message: "AVALANCHE_STRAW_POLL|1|yes|1696288255|x.com/avax/status/<permalink>"
-Signature: "34k8j3w1rxL5wtLCi5AsP93CtjwUWoV5wnyiRucRtSDs9CgAUU8bsYNbgtAAuCmHdG375qa7fimhodxJg2rMxmLfPYrD31E"
-```
-
-* `AVALANCHE_STRAW_POLL` is included to prevent signing a message that could somehow be replayed on-chain.
-* `timestamp` is included so that Avalanche Community members can update their preference if they change their mind as the ACP evolves.
-* `metadata` is an optional field that can be used by Avalanche Community members to link their vote to a social identity (where they must also post the same message + signature) for maintainers to verify before merging.
 
 ### ACP Formats and Templates
 


### PR DESCRIPTION
ACP signaling is a better mechanism for understanding validator support of these proposals. It was introduced in AvalancheGo here: https://github.com/ava-labs/avalanchego/pull/2476 and used successfully for the Durango upgrade ACPs (for example: https://snowpeer.io/acps/23)