### PR TITLE
[ACP-13] Set `Superseded-By` field to `77`

### DIFF
--- a/ACPs/13-subnet-only-validators/README.md
+++ b/ACPs/13-subnet-only-validators/README.md
@@ -5,7 +5,7 @@ Author(s): Patrick O'Grady <contact@patrickogrady.xyz>
 Discussions-To: https://github.com/avalanche-foundation/ACPs/discussions/14
 Status: Stale
 Track: Standards
-Superseded-By: 13
+Superseded-By: 77
 ```
 
 ## Abstract


### PR DESCRIPTION
Was an oversight in the ACP-77 PR, fixing now 🫡