### PR TITLE
clarify SetSubnetValidatorManagerTx

### DIFF
--- a/ACPs/77-reinventing-subnets/README.md
+++ b/ACPs/77-reinventing-subnets/README.md
@@ -157,7 +157,7 @@ The `Message` field in the above transaction must be an Avalanche Warp Message u
                        +----------+
 ```
 
-- `messageID` is the sha256 hash of the warp message in the `RegisterSubnetValidatorTx` that registered the Subnet Validator
+- `messageID` is the sha256 hash of the warp message (subnetID + nodeID + weight + expiry + ed25519 signature, without the BLS multisig part) in the `RegisterSubnetValidatorTx` that registered the Subnet Validator
 - `nonce` is a strictly increasing number that denotes the latest validator weight update and provides replay protection for this transaction. The P-Chain state will store a `minNonce` associated with `messageID`. When accepting the `RegisterSubnetValidatorTx`, the `minNonce` was set to `0` for `messageID`. `nonce` must satisfy `nonce >= minNonce` for `SetSubnetValidatorWeightTx` to be valid. Note that `nonce` is not required to be incremented by `1` with each successive validator weight update. If `minNonce` is `MaxUint64`, the `weight` in the `SetSubnetValidatorWeightTx` is required to be `0` to prevent Subnets from being unable to remove `nodeID` in a future transaction. When a Subnet Validator is removed from the active set (`weight == 0`), the `minNonce` and `messageID` will be removed from the P-Chain state. This state can be reaped during validator exit since `messageID` can never be re-initialized as a result of the replay protection provided by `expiry` in `RegisterSubnetValidatorTx`. `minNonce` will be set to `nonce + 1` when `SetSubnetValidatorWeightTx` is executed and `weight != 0`.
 
 #### ExitValidatorSetTx

--- a/ACPs/77-reinventing-subnets/README.md
+++ b/ACPs/77-reinventing-subnets/README.md
@@ -183,7 +183,9 @@ type ExitValidatorSetTx struct {
 
 To participate in this new registration flow, Subnets must set the `(blockchainID, address)` pair by using `SetSubnetValidatorManagerTx`. This pair will be used to validate the `AddressedCall` in `SetSubnetValidatorWeightTx` and `RegisterSubnetValidatorTx`.
 
-When a Subnet is created with `CreateSubnetTx`, a validator manager is not specified. To solve this problem, the first `SetSubnetValidatorManagerTx` will expect the Warp `AddressedCall` to have the `sourceChainID` be set to the `SubnetID` and the `sourceAddress` to be zero'd out. Once this transaction is accepted, `RegisterSubnetValidatorTx` and `SetSubnetValidatorWeightTx` are enabled for use on the Subnet.
+When a Subnet is created with `CreateSubnetTx`, a validator manager is not specified. To solve this problem, the first `SetSubnetValidatorManagerTx` will expect the Warp `AddressedCall` to have the `SourceChainID` be set to the `SubnetID` and the `SourceAddress` to be zero'd out. This will eventually require the first `SetSubnetValidatorManagerTx` to be manually signed for P-Chain
+
+Once the first `SetSubnetValidatorManagerTx` transaction is accepted, `RegisterSubnetValidatorTx` and `SetSubnetValidatorWeightTx` are enabled for use on the Subnet. Subsequent `SetSubnetValidatorManagerTx` will require `SourceAddress` to be the same as specified `Address` in the payload of previously accepted `SetSubnetValidatorManagerTx`.  
 
 ```golang
 type SetSubnetValidatorManagerTx struct {
@@ -192,7 +194,8 @@ type SetSubnetValidatorManagerTx struct {
     // Warp message should include:
     //   - SubnetID
     //   - ChainID (where the validator manager lives)
-    //   - Address (address of the validator manager)
+    //   - SourceAddress (the source address that created the tx) 
+    //   - Address (specified address of the validator manager)
     //   - BLS multisig over the above payload
     Message warp.Message `json:"message"`
 }


### PR DESCRIPTION
It's a bit hard to follow the difference between `SourceAddress` and `Address`. We should clarify that these are two different fields in the warp message with `AddressedCall` payload 