### PR TITLE
add explicit NodeID check

### DIFF
--- a/ACPs/77-reinventing-subnets/README.md
+++ b/ACPs/77-reinventing-subnets/README.md
@@ -111,6 +111,8 @@ type RegisterSubnetValidatorTx struct {
 
 After the `RegisterSubnetValidatorTx` is accepted on the P-Chain, the Subnet Validator is added to the Subnet's validator set. The P-Chain will then send a Warp message to the Subnet notifying of the validator set addition.
 
+`RegisterSubnetValidatorTx` will be considered invalid if the `NodeID` included in the message is already a validator for the given `SubnetID`.
+
 When any validator is removed from the set (whether forcefully or per the validator's request), the P-Chain will also send a warp message to the Subnet notifying it of the validator set removal. It is up to the Subnet on how to handle such a message, especially if unexpected. A validator's stake could continue to remain locked for an extended period of time after this point, for example.
 
 This transaction is, by design, not required to be submitted by the validator themselves. With the Ed25519 signature, the validator guarantees that they can only be added to the validator set if `Signer` corresponds to the `blsPublicKey` and `Balance` >= `balance`. The `RegisterSubnetValidatorTx` is considered invalid if those two properties are not satisfied.


### PR DESCRIPTION
Added language to clarify that `RegisterSubnetValidatorTx` will check that the Validator[`NodeId`] does not already validate the Subnet before attempting to add it.