### PR TITLE
ACP-118: Specify SignatureRequest handler ID

### DIFF
--- a/ACPs/118-warp-signature-request/README.md
+++ b/ACPs/118-warp-signature-request/README.md
@@ -42,7 +42,9 @@ We propose the following types, implemented as Protobuf types that may be decode
     }
     ```
 
-For each of these types, VMs must implement corresponding `AppRequest` and `AppResponse` handlers to adhere to the interface.
+### Handlers
+
+For each of the above types, VMs must implement corresponding `AppRequest` and `AppResponse` handlers. The `AppRequest` handler should be [registered](https://github.com/ava-labs/avalanchego/blob/v1.11.10-status-removal/network/p2p/network.go#L173) using the canonical handler ID, defined as `1`.
 
 ## Use Cases
 


### PR DESCRIPTION
Updates the ACP-118 specification to include the canonical handler ID that should be used by all VMs to register `SignatureRequest` handler implementations.

Specifies the canonical handler ID as `1`, incrementing from the only other handler ID [registration](https://github.com/ava-labs/avalanchego/blob/v1.11.10-status-removal/network/p2p/network.go#L173), which uses a [handler ID](https://github.com/ava-labs/avalanchego/blob/v1.11.10-status-removal/vms/platformvm/network/network.go#L24) of `0`.