### PR TITLE
ACP 118 - update handler ID and rename field

### DIFF
--- a/ACPs/118-warp-signature-request/README.md
+++ b/ACPs/118-warp-signature-request/README.md
@@ -44,7 +44,7 @@ We propose the following types, implemented as Protobuf types that may be decode
 
 ### Handlers
 
-For each of the above types, VMs must implement corresponding `AppRequest` and `AppResponse` handlers. The `AppRequest` handler should be [registered](https://github.com/ava-labs/avalanchego/blob/v1.11.10-status-removal/network/p2p/network.go#L173) using the canonical handler ID, defined as `1`.
+For each of the above types, VMs must implement corresponding `AppRequest` and `AppResponse` handlers. The `AppRequest` handler should be [registered](https://github.com/ava-labs/avalanchego/blob/v1.11.10-status-removal/network/p2p/network.go#L173) using the canonical handler ID, defined as `2`.
 
 ## Use Cases
 


### PR DESCRIPTION
- Changes the canonical handler ID for `SignatureRequests` to `2` to avoid conflicting with `AtomicTxGossipHandlerID`
- Changes `SignatureRequest.data` to `SignatureRequest.message`, since for all practical purposes, that field specifies a serialized Warp message to be signed.