### PR TITLE
[ACP-125] mark implementable

### DIFF
--- a/ACPs/125-basefee-reduction/README.md
+++ b/ACPs/125-basefee-reduction/README.md
@@ -2,7 +2,7 @@
 | :--- | :--- |
 | **Title** | Reduce C-Chain minimum base fee from 25 nAVAX to 1 nAVAX |
 | **Author(s)** | Stephen Buttolph ([@StephenButtolph](https://github.com/StephenButtolph)), Darioush Jalali ([@darioush](https://github.com/darioush)) |
-| **Status** | Proposed ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/127)) |
+| **Status** | Implementable ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/127)) |
 | **Track** | Standards |
 
 ## Abstract


### PR DESCRIPTION
Given lack of discussions to the contrary and the implementation in [coreth](https://github.com/ava-labs/coreth/pull/604), this PR suggests to mark ACP-125 as implementable