### PR TITLE
Clarify ACP-103 variable initialization

### DIFF
--- a/ACPs/103-dynamic-fees/README.md
+++ b/ACPs/103-dynamic-fees/README.md
@@ -42,6 +42,10 @@ A future ACP could remove the merging of these dimensions to granularly meter us
 
 This mechanism aims to maintain a target gas consumption $T$ per second and adjusts the fee based on the excess gas consumption $x$, defined as the difference between the current gas consumption and $T$.
 
+Prior to the activation of this mechanism, $x$ is initialized:
+
+$$x = 0$$
+
 At the start of building/executing block $b$, $x$ is updated:
 
 $$x = \max(x - (T \cdot \Delta t), 0)$$
@@ -78,7 +82,13 @@ $$x = x + G$$
 
 Whenever $x$ increases by $K$, the gas price increases by a factor of `~2.7`. If the gas price gets too expensive, average gas consumption drops, and $x$ starts decreasing, dropping the price. The gas price constantly adjusts to make sure that, on average, the blockchain consumes $T$ gas per second.
 
-A [leaky bucket](https://en.wikipedia.org/wiki/Leaky_bucket) is employed to meter the maximum rate of gas consumption. Define $L$ as the capacity of the bucket, $S$ as the number of seconds for the bucket to leak $L$ gas ($\frac{L}{S}$ gas leaked per second), and $r$ as the amount of gas that can be added to the bucket without it overflowing. At the beginning of processing block $b$, $r$ is set:
+A [leaky bucket](https://en.wikipedia.org/wiki/Leaky_bucket) is employed to meter the maximum rate of gas consumption. Define $L$ as the capacity of the bucket, $S$ as the number of seconds for the bucket to leak $L$ gas ($\frac{L}{S}$ gas leaked per second), and $r$ as the amount of gas that can be added to the bucket without it overflowing.
+
+Prior to the activation of this mechanism, $r$ is initialized:
+
+$$r = 0$$
+
+At the beginning of processing block $b$, $r$ is set:
 
 $$r = \min\left(r + \frac{L \cdot \Delta{t}}{S}, L\right)$$
 


### PR DESCRIPTION
Currently the specification is unclear as to what the initial value of `x` and `r` are during the fork activation.

I feel like the only "no numbers up my sleeve" choices for these are:
- `x=0`
- `r=0`
- `r=L`

Having `r` initially set to `L` would be the aggressive choice (as it's possible to have the previous block be full, and then 1 second later have `L` complexity issued). The conservative choice (which is what I'm proposing in this PR) is to set the value to `0`. This choice really doesn't impact the mechanism for a long period of time. Just during the network upgrade transition.

We could consider initializing `x` such that the initial price is similar to the current fees... But because the current fees are static, it would need to be based on an average... Calculating this number seems like more complexity than it's worth (as again, these values only really matter shortly after the network upgrade transition.