### PR TITLE
[ACP-77] Adjust nomenclature due to renaming of Avalanche Subnets -> Avalanche L1s

### DIFF
--- a/ACPs/77-reinventing-subnets/README.md
+++ b/ACPs/77-reinventing-subnets/README.md
@@ -1,24 +1,24 @@
-| ACP | 77 |
-| :--- | :--- |
-| **Title** | Reinventing Subnets |
-| **Author(s)** | Dhruba Basu ([@dhrubabasu](https://github.com/dhrubabasu)) |
-| **Status** | Proposed ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/78)) |
-| **Track** | Standards |
-| **Replaces** | [ACP-13](../13-subnet-only-validators/README.md) |
+| ACP           | 77                                                                                   |
+| :------------ | :----------------------------------------------------------------------------------- |
+| **Title**     | Reinventing Subnets                                                                  |
+| **Author(s)** | Dhruba Basu ([@dhrubabasu](https://github.com/dhrubabasu))                           |
+| **Status**    | Proposed ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/78)) |
+| **Track**     | Standards                                                                            |
+| **Replaces**  | [ACP-13](../13-subnet-only-validators/README.md)                                     |
 
 ## Abstract
 
-Overhaul Subnet creation and management to unlock increased flexibility for Subnet creators by:
+Overhaul Subnet creation and management to unlock increased flexibility for layer 1 network creators by:
 
-- Separating Subnet Validators from Primary Network Validators (Primary Network Partial Sync, Removal of 2000 $AVAX requirement)
-- Moving ownership of Subnet Validator set management from P-Chain to Subnets (ERC-20/ERC-721/Arbitrary Staking, Staking Reward Management)
-- Introducing a continuous P-Chain fee mechanism for Subnet Validators (Continuous Subnet Staking)
+- Separating Avalanche Layer 1 Validators from Primary Network Validators (Primary Network Partial Sync, Removal of 2000 $AVAX requirement)
+- Moving ownership of L1 Validator set management from P-Chain to Avalanche Layer 1s (ERC-20/ERC-721/Arbitrary Staking, Staking Reward Management)
+- Introducing a continuous P-Chain fee mechanism for L1 Validators (Continuous L1 Staking)
 
 This ACP supersedes [ACP-13](../13-subnet-only-validators/README.md) and borrows some of its language.
 
 ## Motivation
 
-Each node operator must stake at least 2000 $AVAX ($70k at time of writing) to first become a Primary Network Validator before they qualify to become a Subnet Validator. Most Subnets aim to launch with at least 8 Subnet Validators, which requires staking 16000 $AVAX ($560k at time of writing). All Subnet Validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating.
+Each node operator must stake at least 2000 $AVAX ($70k at time of writing) to first become a Primary Network Validator before they qualify to become a Subnet Validator. Most Subnets aim to launch with at least 8 Subnet validators, which requires staking 16000 $AVAX ($560k at time of writing). All Subnet validators, to satisfy their role as Primary Network Validators, must also [allocate 8 AWS vCPU, 16 GB RAM, and 1 TB storage](https://github.com/ava-labs/avalanchego/blob/master/README.md#installation) to sync the entire Primary Network (X-Chain, P-Chain, and C-Chain) and participate in its consensus, in addition to whatever resources are required for each Subnet they are validating.
 
 Regulated entities that are prohibited from validating permissionless, smart contract-enabled blockchains (like the C-Chain) cannot launch a Subnet because they cannot opt-out of Primary Network Validation. This deployment blocker prevents a large cohort of Real World Asset (RWA) issuers from bringing unique, valuable tokens to the Avalanche Ecosystem (that could move between C-Chain <> Subnets using Avalanche Warp Messaging/Teleporter).
 
@@ -28,15 +28,15 @@ Although the fee paid to the Primary Network to operate a Subnet does not go up 
 
 Elastic Subnets, introduced in [Banff](https://medium.com/avalancheavax/banff-elastic-subnets-44042f41e34c), enabled Subnet creators to activate Proof-of-Stake validation and uptime-based rewards using their own token. However, this token is required to be an ANT (created on the X-Chain) and locked on the P-Chain. All staking rewards were distributed on the P-Chain with the reward curve being defined in the `TransformSubnetTx` and, once set, was unable to be modified.
 
-With no Elastic Subnets live on Mainnet, it is clear that Permissionless Subnets as they stand today could be more desirable. There are many successful Permissioned Subnets in production but many Subnet creators have raised the above as points of concern. In summary, the Avalanche community could benefit from a more flexible and affordable mechanism to launch Permissionless Subnets.
+With no Elastic Subnets live on Mainnet, it is clear that permissionless, sovereign Subnets as they stand today could be more desirable. There are many successful permissioned Subnets in production but many Subnet creators have raised the above as points of concern. In summary, the Avalanche community could benefit from a more flexible and affordable mechanism to launch sovereign, layer 1 blockchain networks.
 
 ## Specification
 
 ### Separate Subnet Validators from Primary Network Validators
 
-Subnet Validators will only be required to sync the P-chain (not X/C-Chain) to track any validator set changes in their Subnet and to support Cross-Subnet communication via Avalanche Warp Messaging (see "Primary Network Partial Sync" mode introduced in [Cortina 8](https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8)). The lower resource requirement in this "minimal mode" will provide Subnets with greater flexibility of validation hardware requirements as operators are not required to reserve any resources for C-Chain/X-Chain operation. Since Subnet Validators are no longer required to validate or sync the Primary Network, the 2000 $AVAX requirement can be removed. To meter the number of Subnet Validators on the network, a significantly lower, continuous fee is introduced later in this ACP.
+L1 Validators will only be required to sync the P-chain (not X/C-Chain) to track any validator set changes in their layer 1 and to support cross-chain communication via Avalanche Warp Messaging (see "Primary Network Partial Sync" mode introduced in [Cortina 8](https://github.com/ava-labs/avalanchego/releases/tag/v1.10.8)). The lower resource requirement in this "minimal mode" will provide layer 1s with greater flexibility of validation hardware requirements as operators are not required to reserve any resources for C-Chain/X-Chain operation. Since layer 1 validators are no longer required to validate or sync the Primary Network, the 2000 $AVAX requirement can be removed. To meter the number of L1 Validators on the network, a significantly lower, continuous fee is introduced later in this ACP.
 
-#### Bootstrapping Subnet Nodes
+#### Bootstrapping L1 Nodes
 
 Bootstrapping a node/validator is the process of securely recreating the latest state of the blockchain locally. At the end of this process, the local state of a node/validator must be in sync with the local state of other virtuous nodes/validators. The node/validator can then verify new incoming transactions and reach consensus with other nodes/validators.
 
@@ -44,22 +44,22 @@ To bootstrap a node/validator, a few critical questions must be answered: How do
 
 For standalone networks like the Avalanche Primary Network, this is done by connecting to a hardcoded [set](https://github.com/ava-labs/avalanchego/blob/master/genesis/bootstrappers.json) of trusted bootstrappers to then discover new peers. Ethereum calls their set [bootnodes](https://ethereum.org/developers/docs/nodes-and-clients/bootnodes).
 
-By separating Subnet Validators from Primary Network Validators, a list of validator IPs to connect to (the functional bootstrappers of the Subnet) is no longer provided by simply connecting to the Primary Network Validators. However, the Primary Network can enable nodes tracking a Subnet to seamlessly connect to the Subnet Validators by tracking and gossiping Subnet Validator IPs. Subnets will not need to operate and maintain a set of bootstrappers and can continue to rely on the Primary Network for peer discovery.
+By separating layer 1 validators from Primary Network Validators, a list of validator IPs to connect to (the functional bootstrappers of the layer 1) is no longer provided by simply connecting to the Primary Network Validators. However, the Primary Network can enable nodes tracking an L1 to seamlessly connect to the L1 validators by tracking and gossiping L1 validator IPs. L1s will not need to operate and maintain a set of bootstrappers and can continue to rely on the Primary Network for peer discovery.
 
-### Setting a Subnet Manager
+### Setting a Validator Manager
 
-To create a Subnet, a `CreateSubnetTx` must be issued on the P-Chain. This transaction includes an `Owner` field which defines the key that must be used to authorize any validator set additions (`AddSubnetValidatorTx`) or removals (`RemoveSubnetValidatorTx`).
+To create an L1, a `CreateSubnetTx` must be issued on the P-Chain. This transaction includes an `Owner` field which defines the key that must be used to authorize any validator set additions (`AddSubnetValidatorTx`) or removals (`RemoveSubnetValidatorTx`).
 
-To be a Permissionless Subnet, this `Owner` key must no longer have the ability to modify the Subnet's validator set. A `ConvertSubnetTx` must first be issued to explicitly convert a Subnet from Permissioned to Permissionless. This transaction will set the `(chainID, address)` pair that will manage the Subnet going forward. After `ConvertSubnetTx` is issued, the `Owner` from the `CreateSubnetTx` that created the Subnet will no longer have the ability to modify the Subnet's validator set.
+To be a sovereign L1, this `Owner` key must no longer have the ability to modify the L1's validator set. A `ConvertL1Tx` must first be issued to explicitly convert an L1 from permissioned to sovereign. This transaction will set the `(chainID, address)` pair that will manage the L1 going forward. After `ConvertL1Tx` is issued, the `Owner` from the `CreateSubnetTx` that created the L1 will no longer have the ability to modify the L1's validator set.
 
-To provide maximal flexibility for Permissionless Subnets, the BLS multisignature approach in Avalanche Warp Messaging (AWM) is re-used to approve modifications to the Subnet's validator set. Using the `(chainID, address)` pair defined in the `ConvertSubnetTx`, a Warp Message with an [`AddressedCall`](https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/warp/payload#addressedcall) payload can be constructed.
+To provide maximal flexibility for sovereign L1s, the BLS multisignature approach in Avalanche Warp Messaging (AWM) is re-used to approve modifications to the L1's validator set. Using the `(chainID, address)` pair defined in the `ConvertL1Tx`, a Warp Message with an [`AddressedCall`](https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/warp/payload#addressedcall) payload can be constructed.
 
-To validate an `AddressedCall` payload in Avalanche Warp Messaging, the `(chainID, address)` pair is used to lookup the validators of `chainID` and verify that the BLS multi-sig includes a quorum (set to 67%) of the Subnet's validator set. The P-Chain will use Warp Messages with `AddressedCall` payloads to support modifications of the Subnet's validator set using this `(chainID, address)` pair (using the `RegisterSubnetValidatorTx` and `SetSubnetValidatorWeightTx` defined later in the specification).
+To validate an `AddressedCall` payload in Avalanche Warp Messaging, the `(chainID, address)` pair is used to lookup the validators of `chainID` and verify that the BLS multi-sig includes a quorum (set to 67%) of the L1's validator set. The P-Chain will use Warp Messages with `AddressedCall` payloads to support modifications of the L1's validator set using this `(chainID, address)` pair (using the `RegisterL1ValidatorTx` and `SetL1ValidatorWeightTx` defined later in the specification).
 
-#### ConvertSubnetTx
+#### ConvertL1Tx
 
 ```golang
-type SubnetValidator struct {
+type L1Validator struct {
     // Must be Ed25519 NodeID
     NodeID ids.NodeID `json:"nodeID"`
     // Weight of this validator used when sampling
@@ -69,34 +69,34 @@ type SubnetValidator struct {
     // [Signer] is the BLS key for this validator.
     // Note: We do not enforce that the BLS key is unique across all validators.
     //       This means that validators can share a key if they so choose.
-    //       However, a NodeID + Subnet does uniquely map to a BLS key
+    //       However, a NodeID + SubnetID does uniquely map to a BLS key
     Signer signer.Signer `json:"signer"`
     // Leftover $AVAX from the [Balance] will be issued to this
     // owner once it is removed from the validator set.
     ChangeOwner fx.Owner `json:"changeOwner"`
 }
 
-type ConvertSubnetTx struct {
+type ConvertL1Tx struct {
     // Metadata, inputs and outputs
     BaseTx
-    // ID of the Subnet to transform
+    // ID of the L1 to transform
     // Restrictions:
     // - Must not be the Primary Network ID
-    Subnet ids.ID `json:"subnetID"`
-    // BlockchainID where the Subnet manager lives
+    SubnetID ids.ID `json:"subnetID"`
+    // BlockchainID where the validator manager lives
     ChainID ids.ID `json:"chainID"`
-    // Address of the Subnet manager
+    // Address of the validator manager
     Address []byte `json:"address"`
-    // Initial pay-as-you-go validators for the Subnet
-    Validators []SubnetValidator `json:"validators"`
+    // Initial pay-as-you-go validators for the L1
+    Validators []L1Validator `json:"validators"`
     // Authorizes this conversion
     SubnetAuth verify.Verifiable `json:"subnetAuthorization"`
 }
 ```
 
-Once this transaction is accepted, `AddSubnetValidatorTx` is disabled on the Subnet going forward. The only action that the `Owner` key is able to take is removing any Subnet validators that were added using `AddSubnetValidatorTx` previously via `RemoveSubnetValidatorTx`. Unless removed by the `Owner` key, any Subnet Validators added previously with an `AddSubnetValidatorTx` will continue to validate the Subnet until their [`End`](https://github.com/ava-labs/avalanchego/blob/a1721541754f8ee23502b456af86fea8c766352a/vms/platformvm/txs/validator.go#L27) time is reached. Once all Subnet Validators added with `AddSubnetValidatorTx` are no longer in the validator set, the `Owner` key is powerless. `RegisterSubnetValidatorTx` and `SetSubnetValidatorWeightTx` must be used to manage the Subnet's validator set going forward.
+Once this transaction is accepted, `AddSubnetValidatorTx` is disabled on the L1 going forward. The only action that the `Owner` key is able to take is removing any Subnet validators that were added using `AddSubnetValidatorTx` previously via `RemoveSubnetValidatorTx`. Unless removed by the `Owner` key, any Subnet validators added previously with an `AddSubnetValidatorTx` will continue to validate the L1 until their [`End`](https://github.com/ava-labs/avalanchego/blob/a1721541754f8ee23502b456af86fea8c766352a/vms/platformvm/txs/validator.go#L27) time is reached. Once all Subnet validators added with `AddSubnetValidatorTx` are no longer in the validator set, the `Owner` key is powerless. `RegisterL1ValidatorTx` and `SetL1ValidatorWeightTx` must be used to manage the L1's validator set going forward.
 
-The `validationID` for validators added through `ConvertSubnetTx` is defined as the SHA256 hash of the 36 bytes resulting from concatenating the 32 byte `convertSubnetTxID` with the 4 byte `validatorIndex` (index in the `Validators` array within the transaction).
+The `validationID` for validators added through `ConvertL1Tx` is defined as the SHA256 hash of the 36 bytes resulting from concatenating the 32 byte `ConvertL1TxID` with the 4 byte `validatorIndex` (index in the `Validators` array within the transaction).
 
 The following serialization is defined as a `ValidatorData`:
 
@@ -112,11 +112,11 @@ The following serialization is defined as a `ValidatorData`:
                           +-----------+
 ```
 
-The following serialization is defined as the `SubnetConversionData`
+The following serialization is defined as the `L1ConversionData`
 
 ```text
 +-------------------+--------------------------+-------------------------------------------------------+
-| convertSubnetTxID :                 [32]byte |                                              32 bytes |
+| ConvertL1TxID :                 [32]byte |                                              32 bytes |
 +-------------------+--------------------------+-------------------------------------------------------+
 |    managerChainID :                 [32]byte |                                              32 bytes |
 +-------------------+--------------------------+-------------------------------------------------------+
@@ -128,7 +128,7 @@ The following serialization is defined as the `SubnetConversionData`
                                                +-------------------------------------------------------+
 ```
 
-Once a `ConvertSubnetTx` is accepted, P-Chain validators must be willing to sign an `AddressedCall` with `sourceChainID` set to the P-Chain ID and the `sourceAddress` set to an empty byte array. The payload of the `AddressedCall` must be:
+Once a `ConvertL1Tx` is accepted, P-Chain validators must be willing to sign an `AddressedCall` with `sourceChainID` set to the P-Chain ID and the `sourceAddress` set to an empty byte array. The payload of the `AddressedCall` must be:
 
 ```text
 +--------------------+----------+----------+
@@ -136,7 +136,7 @@ Once a `ConvertSubnetTx` is accepted, P-Chain validators must be willing to sign
 +--------------------+----------+----------+
 |             typeID :   uint32 |  4 bytes |
 +--------------------+----------+----------+
-| subnetConversionID : [32]byte | 32 bytes |
+| L1ConversionID : [32]byte | 32 bytes |
 +--------------------+----------+----------+
                                 | 38 bytes |
                                 +----------+
@@ -144,16 +144,16 @@ Once a `ConvertSubnetTx` is accepted, P-Chain validators must be willing to sign
 
 - `codecID` is the codec version used to serialize the payload and is hardcoded to `0x0000`
 - `typeID` is the payload type identifier and is `0x00000000` for this message
-- `subnetConversionID` is the SHA256 hash of the `SubnetConversionData` from a given `ConvertSubnetTx`
+- `L1ConversionID` is the SHA256 hash of the `L1ConversionData` from a given `ConvertL1Tx`
 
-### Adding Subnet Validators
+### Adding L1 Validators
 
-#### RegisterSubnetValidatorTx
+#### RegisterL1ValidatorTx
 
-After a `ConvertSubnetTx` has been accepted, the `RegisterSubnetValidatorTx` can be used to add Subnet validators.
+After a `ConvertL1Tx` has been accepted, the `RegisterL1ValidatorTx` can be used to add L1 validators.
 
 ```golang
-type RegisterSubnetValidatorTx struct {
+type RegisterL1ValidatorTx struct {
     // Metadata, inputs and outputs
     BaseTx
     // Balance <= sum($AVAX inputs) - sum($AVAX outputs) - TxFee.
@@ -163,7 +163,7 @@ type RegisterSubnetValidatorTx struct {
     //       This means that validators can share a key if they so choose.
     //       However, a NodeID does uniquely map to a BLS key
     Signer signer.Signer `json:"signer"`
-    // Leftover $AVAX from the Subnet Validator's Balance will be issued to
+    // Leftover $AVAX from the L1 Validator's Balance will be issued to
     // this owner after it is removed from the validator set.
     ChangeOwner fx.Owner `json:"changeOwner"`
     // AddressedCall with Payload:
@@ -200,50 +200,50 @@ The `Message` field must be an `AddressedCall` with the payload:
 
 - `codecID` is the codec version used to serialize the payload and is hardcoded to `0x0000`
 - `typeID` is the payload type identifier and is `0x00000001` for this transaction
-- `subnetID`, `nodeID`, `weight`, and `blsPublicKey` are for the Subnet Validator being added
+- `subnetID`, `nodeID`, `weight`, and `blsPublicKey` are for the L1 Validator being added
 - `expiry` is the time at which this message becomes invalid. As of a P-Chain timestamp `>= expiry`, this Avalanche Warp Message can no longer be used to add the `nodeID` to the validator set of `subnetID`
 
-    `validationID` of validators added via `RegisterSubnetValidatorTx` is defined as the SHA256 hash of the `Payload` of the `AddressedCall`. This SHA256 hash will be used for replay protection. Used `validationID`s will be stored on the P-Chain. If a `RegisterSubnetValidatorTx`'s `validationID` has already been used, the transaction will be considered invalid. To prevent storing an unbounded number of `validationID`s, the `expiry` is required to be no more than 48 hours in the future of the time the transaction is issued on the P-Chain. Any `validationIDs` corresponding to an expired timestamp can be flushed from the P-Chain's state.
+  `validationID` of validators added via `RegisterL1ValidatorTx` is defined as the SHA256 hash of the `Payload` of the `AddressedCall`. This SHA256 hash will be used for replay protection. Used `validationID`s will be stored on the P-Chain. If a `RegisterL1ValidatorTx`'s `validationID` has already been used, the transaction will be considered invalid. To prevent storing an unbounded number of `validationID`s, the `expiry` is required to be no more than 48 hours in the future of the time the transaction is issued on the P-Chain. Any `validationIDs` corresponding to an expired timestamp can be flushed from the P-Chain's state.
 
-Subnets are responsible for defining the procedure on how to retrieve the above information from prospective validators.
+L1s are responsible for defining the procedure on how to retrieve the above information from prospective validators.
 
-An EVM Subnet may choose to implement this step like so:
+An EVM L1 may choose to implement this step like so:
 
-- Use the number of tokens the user has staked into a smart contract on the Subnet to determine the weight of their validator
+- Use the number of tokens the user has staked into a smart contract on the L1 to determine the weight of their validator
 - Require the user to submit an on-chain transaction with their validator information
 - Generate the Warp message
 
-After the `RegisterSubnetValidatorTx` is accepted on the P-Chain, the Subnet Validator is added to the Subnet's validator set. A `minNonce` field corresponding to the `validationID` will be stored on addition to the validator set (initially set to `0`). This field will be used when validating the `SetSubnetValidatorWeightTx` defined below.
+After the `RegisterL1ValidatorTx` is accepted on the P-Chain, the L1 Validator is added to the L1's validator set. A `minNonce` field corresponding to the `validationID` will be stored on addition to the validator set (initially set to `0`). This field will be used when validating the `SetL1ValidatorWeightTx` defined below.
 
-For a `RegisterSubnetValidatorTx` to be valid:
+For a `RegisterL1ValidatorTx` to be valid:
 
 - `Balance` must be >= the greater of 5 $AVAX or two weeks of the current fee
 
-    This prevents Subnet Validators from being added with too low of an initial balance where they become immediately delinquent based on the continuous fee mechanism defined below. A Subnet Validator can leave at any time before the initial $AVAX is consumed and claim the remaining balance to the `ChangeOwner` defined in the transaction.
+  This prevents L1 Validators from being added with too low of an initial balance where they become immediately delinquent based on the continuous fee mechanism defined below. An L1 Validator can leave at any time before the initial $AVAX is consumed and claim the remaining balance to the `ChangeOwner` defined in the transaction.
 
 - `Signer` must correspond to the `blsPublicKey` defined in the warp message
 
-Note: There is no `EndTime` specified in this transaction. Subnet Validators are only removed when a `SetSubnetValidatorWeightTx` sets a validator's weight to `0`.
+Note: There is no `EndTime` specified in this transaction. L1 Validators are only removed when a `SetL1ValidatorWeightTx` sets a validator's weight to `0`.
 
-### Modifying Subnet Validators
+### Modifying L1 Validators
 
-#### SetSubnetValidatorWeightTx
+#### SetL1ValidatorWeightTx
 
-`SetSubnetValidatorWeightTx` is used to modify the voting weight of a Subnet Validator. For this transaction to be valid, 67% of the current Subnet Validator weight must sign the Warp message included in `Message`. Applications of this transaction could include:
+`SetL1ValidatorWeightTx` is used to modify the voting weight of an L1 Validator. For this transaction to be valid, 67% of the current L1 Validator weight must sign the Warp message included in `Message`. Applications of this transaction could include:
 
-- Increase the voting weight of a Subnet Validator if a delegation is made on the Subnet
-- Increase the voting weight of a Subnet Validator if the stake amount is increased (by staking rewards for example)
-- Decrease the voting weight of a misbehaving Subnet Validator
-- Remove an inactive Subnet Validator
+- Increase the voting weight of an L1 Validator if a delegation is made on the L1
+- Increase the voting weight of an L1 Validator if the stake amount is increased (by staking rewards for example)
+- Decrease the voting weight of a misbehaving L1 Validator
+- Remove an inactive L1 Validator
 
-Since there are no `EndTime`s enforced by the P-Chain, Subnets must use this transaction to set an expired validator's weight to `0`. When a validator's weight is set to `0`, they will be removed from the validator set. After the transaction is accepted, any $AVAX remaining in the `Balance` for the Subnet Validator being removed will be returned to the `ChangeOwner` defined in the `RegisterSubnetValidatorTx`.
+Since there are no `EndTime`s enforced by the P-Chain, L1s must use this transaction to set an expired validator's weight to `0`. When a validator's weight is set to `0`, they will be removed from the validator set. After the transaction is accepted, any $AVAX remaining in the `Balance` for the L1 Validator being removed will be returned to the `ChangeOwner` defined in the `RegisterL1ValidatorTx`.
 
 ```golang
-type SetSubnetValidatorWeightTx struct {
+type SetL1ValidatorWeightTx struct {
     // Metadata, inputs and outputs
     BaseTx
     // AddressedCall with Payload:
-    //   - ValidationID (SHA256 of the AddressedCall Payload of the RegisterSubnetValidatorTx adding the validator)
+    //   - ValidationID (SHA256 of the AddressedCall Payload of the RegisterL1ValidatorTx adding the validator)
     //   - Nonce
     //   - Weight
     Message warp.Message `json:"message"`
@@ -270,36 +270,37 @@ The `Message` field must be an `AddressedCall` with the payload:
 
 - `codecID` is the codec version used to serialize the payload and is hardcoded to `0x0000`
 - `typeID` is the payload type identifier and is `0x00000002` for this transaction
-- `validationID` is the SHA256 of the `Payload` of the `AddressedCall` in the `RegisterSubnetValidatorTx` adding the validator to the Subnet's validator set
+- `validationID` is the SHA256 of the `Payload` of the `AddressedCall` in the `RegisterL1ValidatorTx` adding the validator to the L1's validator set
 - `nonce` is a strictly increasing number that denotes the latest validator weight update and provides replay protection for this transaction
 
-    The P-Chain state will store a `minNonce` associated with the `validationID`. When accepting the `RegisterSubnetValidatorTx`, the `minNonce` will be set to `0` for `validationID`. `nonce` must satisfy `nonce >= minNonce` for the `SetSubnetValidatorWeightTx` to be valid. Note that `nonce` is not required to be incremented by `1` with each successive validator weight update. If `minNonce` is `MaxUint64`, the `weight` in the `SetSubnetValidatorWeightTx` is required to be `0` to prevent Subnets from being unable to remove `nodeID` in a subsequent `SetSubnetValidatorWeightTx`. When a Subnet Validator is removed from the active validator set (`weight == 0`), the `minNonce` and `validationID` will be removed from the P-Chain state. This state can be reaped during validator removal since `validationID` can never be re-initialized as a result of the replay protection provided by `expiry` in `RegisterSubnetValidatorTx`. `minNonce` will be set to `nonce + 1` when `SetSubnetValidatorWeightTx` is executed and `weight != 0`
+  The P-Chain state will store a `minNonce` associated with the `validationID`. When accepting the `RegisterL1ValidatorTx`, the `minNonce` will be set to `0` for `validationID`. `nonce` must satisfy `nonce >= minNonce` for the `SetL1ValidatorWeightTx` to be valid. Note that `nonce` is not required to be incremented by `1` with each successive validator weight update. If `minNonce` is `MaxUint64`, the `weight` in the `SetL1ValidatorWeightTx` is required to be `0` to prevent L1s from being unable to remove `nodeID` in a subsequent `SetL1ValidatorWeightTx`. When an L1 Validator is removed from the active validator set (`weight == 0`), the `minNonce` and `validationID` will be removed from the P-Chain state. This state can be reaped during validator removal since `validationID` can never be re-initialized as a result of the replay protection provided by `expiry` in `RegisterL1ValidatorTx`. `minNonce` will be set to `nonce + 1` when `SetL1ValidatorWeightTx` is executed and `weight != 0`
+
 - `weight` is the new `weight` of the validator
 
-### Removing Subnet Validators
+### Removing L1 Validators
 
-#### SetSubnetValidatorWeightTx (Weight = 0)
+#### SetL1ValidatorWeightTx (Weight = 0)
 
-Issuing a `SetSubnetValidatorWeightTx` with `Weight` of `0` will remove the Subnet Validator from the Subnet's validator set.
+Issuing a `SetL1ValidatorWeightTx` with `Weight` of `0` will remove the L1 Validator from the L1's validator set.
 
-All state related to the Subnet Validator being removed will be removed from the P-Chain's active state (BLS key, NodeID etc). This validator can be newly added to the Subnet's validator set using the `RegisterSubnetValidatorTx` flow.
+All state related to the L1 validator being removed will be removed from the P-Chain's active state (BLS key, NodeID etc). This validator can be newly added to the L1's validator set using the `RegisterL1ValidatorTx` flow.
 
-If all Subnet Validators are removed, there are no valid Warp messages that can be produced to register new Subnet Validators through `RegisterSubnetValidatorTx`. With no validators, block production will halt and the Subnet is unrecoverable. To serve as a guardrail against this situation, a Subnet Validator removal will be considered invalid if the validator being removed is the last one. A future ACP can remove this guardrail as users get more familiar with the new Subnet mechanics and tooling matures to fork a Subnet.
+If all L1 validators are removed, there are no valid Warp messages that can be produced to register new L1 validators through `RegisterL1ValidatorTx`. With no validators, block production will halt and the L1 is unrecoverable. To serve as a guardrail against this situation, an L1 validator removal will be considered invalid if the validator being removed is the last one. A future ACP can remove this guardrail as users get more familiar with the new L1 mechanics and tooling matures to fork an L1.
 
-### Disabling Subnet Validators
+### Disabling L1 Validators
 
-#### DisableValidatorTx
+#### DisableL1ValidatorTx
 
-Subnet Validators can use `DisableValidatorTx` to mark their validator as inactive. Notably, there is no requirement of any interaction on the Subnet to issue this transaction. The only requirement is an Ed25519 Signature (signed with the Subnet Validator's Ed25519 private key) for this transaction to be valid. Any remaining $AVAX in the Subnet Validator's `Balance` will be issued to the `ChangeOwner` defined when this validator was added to the validator set.
+L1 validators can use `DisableL1ValidatorTx` to mark their validator as inactive. Notably, there is no requirement of any interaction on the L1 to issue this transaction. The only requirement is an Ed25519 Signature (signed with the L1 validator's Ed25519 private key) for this transaction to be valid. Any remaining $AVAX in the L1 validator's `Balance` will be issued to the `ChangeOwner` defined when this validator was added to the validator set.
 
-The expected path for full removal from a Subnet's validator set is via a `SetSubnetValidatorWeightTx` with weight `0` which requires a Warp message produced by the Subnet. However, the ability to stop participating in Subnet validation is critical for censorship-resistance and/or failed Subnets. If a Subnet Validator wishes to stop participating in its Subnet's consensus, they can do so through this transaction. This is enabled on the P-Chain to prevent Subnets from locking Subnet Validators into participating in consensus indefinitely.
+The expected path for full removal from an L1's validator set is via a `SetL1ValidatorWeightTx` with weight `0` which requires a Warp message produced by the L1. However, the ability to stop participating in L1 validation is critical for censorship-resistance and/or failed L1s. If an L1 Validator wishes to stop participating in its L1's consensus, they can do so through this transaction. This is enabled on the P-Chain to prevent L1s from locking L1 validators into participating in consensus indefinitely.
 
-Note that this does not modify a Subnet's total staking weight. This transaction only marks the Subnet Validator as inactive but does not remove it from the Subnet's validator set. Inactive Subnet Validators can re-activate at any time by increasing their balance with an `IncreaseBalanceTx`.
+Note that this does not modify an L1's total staking weight. This transaction only marks the L1 validator as inactive but does not remove it from the L1's validator set. Inactive L1 validators can re-activate at any time by increasing their balance with an `IncreaseL1ValidatorBalanceTx`.
 
-Subnet creators should be aware that there is no notion of `MinStakeDuration` that is enforced by the P-Chain. It is expected that Subnets who choose to enforce a `MinStakeDuration` will lock the validator's Stake for the Subnet's desired `MinStakeDuration`.
+L1 creators should be aware that there is no notion of `MinStakeDuration` that is enforced by the P-Chain. It is expected that L1s who choose to enforce a `MinStakeDuration` will lock the validator's Stake for the L1's desired `MinStakeDuration`.
 
 ```golang
-type DisableValidatorTx struct {
+type DisableL1ValidatorTx struct {
     // Metadata, inputs and outputs
     BaseTx
     // ID corresponding to the validator
@@ -309,15 +310,15 @@ type DisableValidatorTx struct {
 }
 ```
 
-### Proof of Subnet Validator Set Change
+### Proof of L1 Validator Set Change
 
-To track whether a Subnet Validator addition/modification/removal occured on the P-Chain, Subnet Validators must be willing to sign an `AddressedCall` attesting to the validator set change. Since all Subnet Validators sync the P-Chain, only the Subnet Validators need to sign the `AddressedCall`, not all Primary Network Validators.
+To track whether an L1 Validator addition/modification/removal occured on the P-Chain, L1 validators must be willing to sign an `AddressedCall` attesting to the validator set change. Since all L1 validators sync the P-Chain, only the L1 validators need to sign the `AddressedCall`, not all Primary Network Validators.
 
 Two `AddressedCall`s are defined with the below payloads. For each of them, the `sourceChainID` must be set to the P-Chain ID and the `sourceAddress` must be set to an empty byte array.
 
 The method of requesting is left unspecified as it can be more generic. A viable option for supporting this functionality is laid out in [ACP-118](../118-warp-signature-request/README.md) with the `SignatureRequest` message.
 
-#### SubnetValidatorRegistrationMessage
+#### L1ValidatorRegistrationMessage
 
 ```text
 +--------------+----------+----------+
@@ -327,7 +328,7 @@ The method of requesting is left unspecified as it can be more generic. A viable
 +--------------+----------+----------+
 | validationID : [32]byte | 32 bytes |
 +--------------+----------+----------+
-|   registered :     bool |  1 byte  | 
+|   registered :     bool |  1 byte  |
 +--------------+----------+----------+
                           | 39 bytes |
                           +----------+
@@ -335,12 +336,12 @@ The method of requesting is left unspecified as it can be more generic. A viable
 
 - `codecID` is the codec version used to serialize the payload and is hardcoded to `0x0000`
 - `typeID` is the payload type identifier and is `0x00000003` for this message
-- `validationID` is the SHA256 of the `Payload` of the `AddressedCall` in the `RegisterSubnetValidatorTx` adding the validator to the Subnet's validator set
+- `validationID` is the SHA256 of the `Payload` of the `AddressedCall` in the `RegisterL1ValidatorTx` adding the validator to the L1's validator set
 - `registered` indicates whether or not the `validationID` corresponds to a valid `AddressedCall` payload. If true, `validationID` corresponds to an active validator. If false, `validationID` does not correspond to an active validator, and never will as the `expiry` in the `AddressedCall` payload has been reached.
 
-The P-Chain nodes must refuse to sign any `SubnetValidatorRegistrationMessage` where the `validationID` does not correspond to an active validator and the `expiry` is in the future.
+The P-Chain nodes must refuse to sign any `L1ValidatorRegistrationMessage` where the `validationID` does not correspond to an active validator and the `expiry` is in the future.
 
-#### SubnetValidatorWeightUpdateMessage
+#### L1ValidatorWeightUpdateMessage
 
 ```text
 +--------------+----------+----------+
@@ -360,20 +361,20 @@ The P-Chain nodes must refuse to sign any `SubnetValidatorRegistrationMessage` w
 
 - `codecID` is the codec version used to serialize the payload and is hardcoded to `0x0000`
 - `typeID` is the payload type identifier and is `0x00000004` for this message
-- `validationID` is the SHA256 of the `Payload` of the `AddressedCall` in the `RegisterSubnetValidatorTx` adding the validator to the Subnet's validator set
+- `validationID` is the SHA256 of the `Payload` of the `AddressedCall` in the `RegisterL1ValidatorTx` adding the validator to the L1's validator set
 - `nonce` is the latest nonce stored with the `validationID` on the P-Chain
-- `weight` is the current weight of the Subnet Validator with `validationID`
+- `weight` is the current weight of the L1 Validator with `validationID`
 
-### Managing Subnet Validator Balance
+### Managing L1 Validator Balance
 
-#### IncreaseBalanceTx
+#### IncreaseL1ValidatorBalanceTx
 
-This transaction can be issued by anybody to add additional $AVAX to the `Balance` for `NodeID` validating `Subnet`. If the Subnet Validator corresponding to `ValidationID` is currently inactive (`Balance` was exhausted or `DisableValidatorTx` was issued), this transaction will move them back to the active validator set.
+This transaction can be issued by anybody to add additional $AVAX to the `Balance` for `NodeID` validating `SubnetID`. If the L1 validator corresponding to `ValidationID` is currently inactive (`Balance` was exhausted or `DisableL1ValidatorTx` was issued), this transaction will move them back to the active validator set.
 
-Note: The $AVAX added to `Balance` can be claimed at any time by the Subnet Validator using `DisableValidatorTx`.
+Note: The $AVAX added to `Balance` can be claimed at any time by the L1 validator using `DisableL1ValidatorTx`.
 
 ```golang
-type IncreaseBalanceTx struct {
+type IncreaseL1ValidatorBalanceTx struct {
     // Metadata, inputs and outputs
     BaseTx
     // ID corresponding to the validator
@@ -383,23 +384,23 @@ type IncreaseBalanceTx struct {
 }
 ```
 
-### Sidebar: Subnet Sovereignty
+### Sidebar: L1 Sovereignty
 
-After this ACP is activated, the P-Chain will no longer support staking of any assets other than $AVAX for the Primary Network. The P-Chain will no longer support distribution of staking rewards for Subnets. All staking-related operations for Subnet Validation must be managed by the Subnet on the Subnet. The P-Chain simply requires a continuous fee per Subnet Validator. If a Subnet would like to manage their Validator's balances on the P-Chain, it can cover the cost for all Subnet Validators by posting the $AVAX balance on the P-Chain. Subnets can implement any mechanism they want to pay the continuous fee charged by the P-Chain for its participants.
+After this ACP is activated, the P-Chain will no longer support staking of any assets other than $AVAX for the Primary Network. The P-Chain will no longer support distribution of staking rewards for Subnets. All staking-related operations for L1 Validation must be managed by the L1 Validator Manager on the L1. The P-Chain simply requires a continuous fee per L1 Validator. If an L1 would like to manage its validator's balances on the P-Chain, it can cover the cost for all L1 validators by posting the $AVAX balance on the P-Chain. L1s can implement any mechanism they want to pay the continuous fee charged by the P-Chain for its participants.
 
-By moving ownership of the Subnet's validator set from the P-Chain to the Subnet, Subnet creators have no restrictions on what requirements they have to join their Subnet as a validator. Any stake that is required to join the Subnet's validator set is locked on the Subnet. If a validator is removed from the Subnet's validator set via a `SetSubnetValidatorWeightTx` with weight `0`, the stake on the Subnet will continue to be locked. How each Subnet handles stake associated with the Subnet Validator is entirely left up to the Subnet and can be treated independently to what happens on the P-Chain.
+By moving ownership of the Subnet's validator set from the P-Chain to the L1, L1 creators have no restrictions on what requirements they have to join their L1 as a validator. Any stake that is required to join the L1's validator set is locked on the L1. If a validator is removed from the L1's validator set via a `SetL1ValidatorWeightTx` with weight `0`, the stake on the L1 will continue to be locked. How each L1 handles stake associated with the L1 validator is entirely left up to the L1 and can be treated independently to what happens on the P-Chain.
 
-This new relationship between the P-Chain and Subnets provides a dynamic where Subnets can use the P-Chain as an impartial judge to modify parameters (in addition to its existing role of helping to validate incoming Avalanche Warp Messages). If a Validator is misbehaving, the Subnet Validators can collectively generate a BLS multisig to reduce the voting weight of a misbehaving validator. This operation is fully secured by the Avalanche Primary Network (225M $AVAX or $8.325B at the time of writing).
+This new relationship between the P-Chain and L1s provides a dynamic where L1s can use the P-Chain as an impartial judge to modify parameters (in addition to its existing role of helping to validate incoming Avalanche Warp Messages). If a validator is misbehaving, the L1 validators can collectively generate a BLS multisig to reduce the voting weight of a misbehaving validator. This operation is fully secured by the Avalanche Primary Network (225M $AVAX or $8.325B at the time of writing).
 
-Follow-up ACPs could extend the P-Chain <> Subnet relationship to include parametrization of the 67% threshold to enable Subnets to choose a different threshold based on their security model (e.g. a simple majority of 51%).
+Follow-up ACPs could extend the P-Chain <> L1 relationship to include parametrization of the 67% threshold to enable L1s to choose a different threshold based on their security model (e.g. a simple majority of 51%).
 
 ### Continuous Fee Mechanism
 
-Every additional Subnet Validator on the P-Chain adds persistent load to the Avalanche Network. When a validator transaction is issued on the P-Chain, it is charged for the computational cost of the transaction itself but is not charged for the cost of an active Subnet Validator over the time they are validating on the network (which may be indefinitely). This is a common problem in blockchains, spawning many state rent proposals in the broader blockchain space to address it. The following fee mechanism takes advantage of the fact that each Subnet Validator uses the same amount of computation and charges each Subnet Validator the dynamic base fee for every discrete unit of time it is active.
+Every additional L1 Validator on the P-Chain adds persistent load to the Avalanche Network. When a validator transaction is issued on the P-Chain, it is charged for the computational cost of the transaction itself but is not charged for the cost of an active L1 validator over the time they are validating on the network (which may be indefinitely). This is a common problem in blockchains, spawning many state rent proposals in the broader blockchain space to address it. The following fee mechanism takes advantage of the fact that each L1 validator uses the same amount of computation and charges each L1 validator the dynamic base fee for every discrete unit of time it is active.
 
-To charge each Subnet Validator, the notion of a `Balance` is introduced. The `Balance` of a Subnet Validator will be continuously charged during the time they are active to cover the cost of storing the associated validator properties (BLS key, weight, nonce) in memory and to track IPs (in addition to other services provided by the Primary Network). This `Balance` is initialized with the `RegisterSubnetValidatorTx` that added them to the active validator set. `Balance` can be increased at any time using the `IncreaseBalanceTx`. When this `Balance` reaches `0`, the Subnet Validator will be considered "inactive" and will no longer participate in validating the Subnet. Inactive Subnet Validators can be moved back to the active validator set at any time using the same `IncreaseBalanceTx`. Once a Subnet Validator is considered inactive, the P-Chain will remove these properties from memory and only retain them on disk. All messages from that validator will be considered invalid until it is revived using the `IncreaseBalanceTx`. Subnets can reduce the amount of inactive weight by removing inactive validators with the `SetSubnetValidatorWeightTx` (`Weight` = 0).
+To charge each L1 validator, the notion of a `Balance` is introduced. The `Balance` of an L1 validator will be continuously charged during the time they are active to cover the cost of storing the associated validator properties (BLS key, weight, nonce) in memory and to track IPs (in addition to other services provided by the Primary Network). This `Balance` is initialized with the `RegisterL1ValidatorTx` that added them to the active validator set. `Balance` can be increased at any time using the `IncreaseL1ValidatorBalanceTx`. When this `Balance` reaches `0`, the L1 validator will be considered "inactive" and will no longer participate in validating the L1. Inactive L1 validators can be moved back to the active validator set at any time using the same `IncreaseL1ValidatorBalanceTx`. Once an L1 validator is considered inactive, the P-Chain will remove these properties from memory and only retain them on disk. All messages from that validator will be considered invalid until it is revived using the `IncreaseL1ValidatorBalanceTx`. L1s can reduce the amount of inactive weight by removing inactive validators with the `SetL1ValidatorWeightTx` (`Weight` = 0).
 
-Since each Subnet Validator is charged the same amount at each point in time, tracking the fees for the entire validator set is straight-forward. The accumulated dynamic base fee for the entire network is tracked in a single uint. This accumulated value should be equal to the fee charged if a Subnet Validator was active from the time the accumulator was instantiated. The validator set is maintained in a priority queue. A pseudocode implementation of the continuous fee mechanism is provided below.
+Since each L1 validator is charged the same amount at each point in time, tracking the fees for the entire validator set is straight-forward. The accumulated dynamic base fee for the entire network is tracked in a single uint. This accumulated value should be equal to the fee charged if an L1 validator was active from the time the accumulator was instantiated. The validator set is maintained in a priority queue. A pseudocode implementation of the continuous fee mechanism is provided below.
 
 ```python
 # Pseudocode
@@ -408,11 +409,11 @@ class ValidatorQueue:
         self.acc = 0
         self.queue = PriorityQueue()
         self.fee_getter = fee_getter
-    
-    # At each time period, increment the accumulator and 
-    # pop all validators from the top of the queue that 
+
+    # At each time period, increment the accumulator and
+    # pop all validators from the top of the queue that
     # ran out of funds.
-    
+
     # Note: The amount of work done in a single block
     # should be bounded to prevent a large number of
     # validator operations from happening at the same
@@ -447,17 +448,17 @@ class ValidatorQueue:
 
 #### Fee Algorithm
 
-[ACP-103](../103-dynamic-fees/README.md) proposes a dynamic fee mechanism for transactions on the P-Chain. This mechanism is repurposed with minor modifications for the active Subnet Validator continuous fee.
+[ACP-103](../103-dynamic-fees/README.md) proposes a dynamic fee mechanism for transactions on the P-Chain. This mechanism is repurposed with minor modifications for the active L1 validator continuous fee.
 
-At activation, the number of excess active Subnet Validators $x$ is set to `0`.
+At activation, the number of excess active L1 validators $x$ is set to `0`.
 
-The fee rate per second for an active Subnet Validator is:
+The fee rate per second for an active L1 validator is:
 
 $$M \cdot \exp\left(\frac{x}{K}\right)$$
 
 Where:
 
-- $M$ is the minimum price for an active Subnet Validator
+- $M$ is the minimum price for an active L1 validator
 - $\exp\left(x\right)$ is an approximation of $e^x$ following the EIP-4844 specification
 
   ```python
@@ -473,7 +474,7 @@ Where:
     return output // denominator
   ```
 
-- $K$ is a constant to control the rate of change for the Subnet Validator price
+- $K$ is a constant to control the rate of change for the L1 validator price
 
 After every second, $x$ will be updated:
 
@@ -481,20 +482,20 @@ $$x = \max(x + (V - T), 0)$$
 
 Where:
 
-- $V$ is the number of active Subnet Validators
-- $T$ is the target number of active Subnet Validators
+- $V$ is the number of active L1 validators
+- $T$ is the target number of active L1 validators
 
-Whenever $x$ increases by $K$, the price per active Subnet Validator increases by a factor of `~2.7`. If the price per active Subnet Validator gets too expensive, some active Subnet Validators will exit the active validator set, decreasing $x$, dropping the price. The price per active Subnet Validator constantly adjusts to make sure that, on average, the P-Chain has no more than $T$ active Subnet Validators.
+Whenever $x$ increases by $K$, the price per active L1 validator increases by a factor of `~2.7`. If the price per active L1 validator gets too expensive, some active L1 validators will exit the active validator set, decreasing $x$, dropping the price. The price per active L1 validator constantly adjusts to make sure that, on average, the P-Chain has no more than $T$ active L1 validators.
 
 #### Block Timestamp Validity Change
 
-To ensure that validators are removed timely, blocks are considered valid if their timestamps are no greater than the time at which the first Subnet Validator gets removed from a lack of funds. This upholds the expectation that the number of Subnet Validators remains constant between blocks.
+To ensure that validators are removed timely, blocks are considered valid if their timestamps are no greater than the time at which the first L1 validator gets removed from a lack of funds. This upholds the expectation that the number of L1 validators remains constant between blocks.
 
-The block building protocol is modified to account for this change by first checking if the wall clock time removes any Subnet Validator due to a lack of funds. If the wall clock time does not remove any Subnet Validators, the wall clock time is used to build the block. If it does, the time at which the first Subnet Validator gets removed is used.
+The block building protocol is modified to account for this change by first checking if the wall clock time removes any L1 validator due to a lack of funds. If the wall clock time does not remove any L1 validators, the wall clock time is used to build the block. If it does, the time at which the first L1 validator gets removed is used.
 
 #### Fee Calculation
 
-Prior to processing the next block, the total Subnet Validator fee assessed in the $\Delta t$ between the current block and the next block is:
+Prior to processing the next block, the total L1 validator fee assessed in the $\Delta t$ between the current block and the next block is:
 
 ```python
 # Calculate the fee to charge over Δt
@@ -510,32 +511,33 @@ def cost_over_time(V:int, T:int, x:int, Δt: int) -> int:
 
 The parameters at activation are:
 
-| Parameter | Value |
-| - | - |
-| $T$ | `TODO` Subnet Validators |
-| $C$ | `TODO` Subnet Validators |
-| $M$ | `TODO` nAVAX/s (`TODO` AVAX/day) |
-| $K$ | `TODO` |
+| Parameter | Value                            |
+| --------- | -------------------------------- |
+| $T$       | `TODO` L1 validators             |
+| $C$       | `TODO` L1 validators             |
+| $M$       | `TODO` nAVAX/s (`TODO` AVAX/day) |
+| $K$       | `TODO`                           |
 
 A future ACP can adjust the parameters to increase $T$, reduce $M$, and/or modify $K$.
 
 #### User Experience
 
-Instead of a fixed up-front cost of 2000 $AVAX, Subnet Validators are now continuously charged a fee, albeit a small one. This poses a new challenge for Subnet Validators: How do they maintain the Subnet Validator balance?
+Instead of a fixed up-front cost of 2000 $AVAX, L1 validators are now continuously charged a fee, albeit a small one. This poses a new challenge for L1 validators: How do they maintain the L1 validator balance?
 
-Node clients should expose an API to track how much balance is remaining in the Subnet Validator's account. This will provide a way for Subnet Validators to track how quickly it is going down and top-up when needed. A nice byproduct of the above design is the balance in the Subnet Validator's account is claimable. This means users can top-up as much $AVAX as they want and rest-assured knowing they can always retrieve it if there is an excessive amount.
+Node clients should expose an API to track how much balance is remaining in the L1 validator's account. This will provide a way for L1 validators to track how quickly it is going down and top-up when needed. A nice byproduct of the above design is the balance in the L1 validator's account is claimable. This means users can top-up as much $AVAX as they want and rest-assured knowing they can always retrieve it if there is an excessive amount.
 
-The expectation is that most users will not interact with node clients or track when or how much they need to top-up their Subnet Validator account. Wallet providers will abstract away most of this process. For users who desire more convenience, Subnet-as-a-Service providers will abstract away all of this process.
+The expectation is that most users will not interact with node clients or track when or how much they need to top-up their L1 validator account. Wallet providers will abstract away most of this process. For users who desire more convenience, L1-as-a-Service providers will abstract away all of this process.
 
 ## Backwards Compatibility
 
-This new design for Subnets proposes a large re-work to all Subnet-related mechanics. Rollout should be done on a going-forward basis to not cause any service disruption for live Subnets. All current Subnet Validators will be able to continue validating both the Primary Network and whatever Subnets they are validating.
+This new design for L1s proposes a large re-work to all L1-related mechanics. Rollout should be done on a going-forward basis to not cause any service disruption for live Subnets. All current Subnet validators will be able to continue validating both the Primary Network and whatever Subnets/L1s they are validating.
 
 Any state execution changes must be coordinated through a mandatory upgrade. Implementors must take care to continue to verify the existing ruleset until the upgrade is activated. After activation, nodes should verify the new ruleset. Implementors must take care to only verify the presence of 2000 $AVAX prior to activation.
 
 ### Deactivated Transactions
 
 - P-Chain
+
   - `TransformSubnetTx`
 
     After this ACP is activated, Elastic Subnets will be disabled. `TransformSubnetTx` will not be accepted post-activation. As there are no Mainnet Elastic Subnets, there should be no production impact with this deactivation.
@@ -543,11 +545,11 @@ Any state execution changes must be coordinated through a mandatory upgrade. Imp
 ### New Transactions
 
 - P-Chain
-  - `ConvertSubnetTx`
-  - `RegisterSubnetValidatorTx`
-  - `SetSubnetValidatorWeightTx`
-  - `DisableValidatorTx`
-  - `IncreaseBalanceTx`
+  - `ConvertL1Tx`
+  - `RegisterL1ValidatorTx`
+  - `SetL1ValidatorWeightTx`
+  - `DisableL1ValidatorTx`
+  - `IncreaseL1ValidatorBalanceTx`
 
 ## Reference Implementation
 
@@ -555,21 +557,21 @@ A full reference implementation has not been provided yet. It will be provided o
 
 ## Security Considerations
 
-This ACP significantly reduces the cost of becoming a Subnet Validator. This can lead to a large increase in the number of Subnet Validators going forward. Each additional Subnet Validator adds consistent RAM usage to the P-Chain. However, this should be appropriately metered by the continuous fee mechanism outlined above.
+This ACP significantly reduces the cost of becoming an L1 validator. This can lead to a large increase in the number of L1 validators going forward. Each additional L1 validator adds consistent RAM usage to the P-Chain. However, this should be appropriately metered by the continuous fee mechanism outlined above.
 
-With the additional sovereignty Subnets gain from the P-Chain, Subnet staking tokens are no longer locked on the P-Chain for Permissionless Subnets. This poses a new security consideration for Subnet Validators: Malicious Subnets can choose to remove validators at will and take any funds that the Subnet Validator has on the Subnet. The P-Chain only provides the guarantee that Subnet Validators can retrieve the remaining $AVAX Balance for their Validator via a `DisableValidatorTx`. Any assets on the Subnet is entirely under the purview of the Subnet. The onus is now on Subnet Validators to vet the Subnet's security.
+With the additional sovereignty L1s gain from the P-Chain, L1 staking tokens are no longer locked on the P-Chain for sovereign L1s. This poses a new security consideration for L1 validators: Malicious L1s can choose to remove validators at will and take any funds that the L1 validator has on the L1. The P-Chain only provides the guarantee that L1 validators can retrieve the remaining $AVAX Balance for their Validator via a `DisableL1ValidatorTx`. Any assets on the L1 are entirely under the purview of the L1. The onus is now on L1 validators to vet the L1's security.
 
-With a long window of expiry (48 hours) for the Warp message in `RegisterSubnetValidatorTx`, spam of Subnet Validator registration could lead to high memory pressure on the P-Chain. A future ACP can reduce the window of expiry if 48 hours proves to be a problem.
+With a long window of expiry (48 hours) for the Warp message in `RegisterL1ValidatorTx`, spam of L1 validator registration could lead to high memory pressure on the P-Chain. A future ACP can reduce the window of expiry if 48 hours proves to be a problem.
 
-NodeIDs can be added to a Subnet's validator set involuntarily. However, it is important to note that any stake/rewards are _not_ at risk. For a node operator who was added to a validator set involuntarily, they would only need to generate a new NodeID via key rotation as there is no lock-up of any stake to create a NodeID. This is an explicit tradeoff for easier on-boarding of NodeIDs. This mirrors the Primary Network Validators guarantee of no stake/rewards at risk.
+NodeIDs can be added to a L1's validator set involuntarily. However, it is important to note that any stake/rewards are _not_ at risk. For a node operator who was added to a validator set involuntarily, they would only need to generate a new NodeID via key rotation as there is no lock-up of any stake to create a NodeID. This is an explicit tradeoff for easier on-boarding of NodeIDs. This mirrors the Primary Network Validators guarantee of no stake/rewards at risk.
 
-The continuous fee mechanism outlined above does not apply to inactive Subnet Validators since they are not stored in memory. However, inactive Subnet Validators are persisted on disk which can lead to persistent P-Chain state growth. The initial balance requirement (the greater of 5 $AVAX or two weeks of the current fee) should be a sufficient deterrent as it must be fully burned for the Subnet Validator to become inactive. A future ACP can increase the initial balance to decrease the rate of P-Chain state growth or provide a state expiry path to reduce the amount of P-Chain state.
+The continuous fee mechanism outlined above does not apply to inactive L1 validators since they are not stored in memory. However, inactive L1 validators are persisted on disk which can lead to persistent P-Chain state growth. The initial balance requirement (the greater of 5 $AVAX or two weeks of the current fee) should be a sufficient deterrent as it must be fully burned for the L1 validator to become inactive. A future ACP can increase the initial balance to decrease the rate of P-Chain state growth or provide a state expiry path to reduce the amount of P-Chain state.
 
 ## Open Questions
 
-### Should they still be called Subnets?
+### Subnets Are Now Called L1s
 
-Through this ACP, Subnets have far more sovereignty than they did before. The Avalanche Community could take this opportunity to re-brand Subnets.
+Avalanche Subnets have been renamed: Avalanche L1s. Unlike layer 2 blockchains, layer 1 blockchains operate independently without relying on other systems for their core functions. They manage their own consensus mechanisms, transaction processing, and security protocols directly within their own networks. Subnets have always operated this way, scaling Avalanche's network horizontally instead of compounding dependencies by requiring chains to roll down to other networks.
 
 ## Acknowledgements
 


### PR DESCRIPTION
As stated in this Avalanche Academy [Guide](https://academy.avax.network/guide/etna-changes#subnets-are-now-called-l1s): _Avalanche Subnets have been rebranded as Avalanche L1s._ 

To avoid confusion, the spec has been revised to account for this, including the following changes: 

```
ConvertSubnetTx -> ConvertL1Tx
RegisterSubnetValidatorTx -> RegisterL1ValidatorTx
RegisterSubnetValidatorMessage -> RegisterL1ValidatorMessage
SetSubnetValidatorWeightTx -> SetL1ValidatorWeightTx
DisableValidatorTx -> DisableL1ValidatorTx
SubnetValidatorRegistrationMessage -> L1ValidatorRegistrationMessage
IncreaseBalanceTx -> IncreaseL1ValidatorBalanceTx 
```

### To Review:

[ReadMe Preview](https://github.com/meaghanfitzgerald/ACPs/blob/nomenclature-change/ACPs/77-reinventing-subnets/README.md)

### Nuance:

- `Subnet validator` continues to refer to all validators created and controlled by Subnet Owners pre-Etna Upgrade, controllable by the `AddSubnetValidatorTx` and `RemoveSubnetValidatorTx`. 
- `CreateSubnetTx` is a pre-Etna transaction whose functionality and nomenclature will not change within this spec. 
- `SubnetID` is the transaction hash produced by a successful `CreateSubnetTx` and a parameter required by some of the new transaction types. This will not be renamed. 