### PR TITLE
ACP-77: Include description of post-tx processing eviction

### DIFF
--- a/ACPs/77-reinventing-subnets/README.md
+++ b/ACPs/77-reinventing-subnets/README.md
@@ -491,7 +491,7 @@ Whenever $x$ increases by $K$, the price per active L1 validator increases by a 
 
 #### Block Processing
 
-Before processing the transactions inside a block, all validators that no longer have a sufficient, non-zero, balance are deactivated.
+Before processing the transactions inside a block, all validators that no longer have a sufficient (non-zero) balance are deactivated.
 
 After processing the transactions inside a block, all validators that do not have a sufficient balance for the next second are deactivated.
 


### PR DESCRIPTION
In order to prevent malicious clients from artificially increasing the ACP-77 fee, it must be ensured that L1 validators are charged for increasing the fee excess.