### PR TITLE
acp-131: mark implementable

### DIFF
--- a/ACPs/131-cancun-eips/README.md
+++ b/ACPs/131-cancun-eips/README.md
@@ -2,7 +2,7 @@
 | :--- | :--- |
 | **Title** | Activate Cancun EIPs on C-Chain and Subnet-EVM chains |
 | **Author(s)** | Darioush Jalali ([@darioush](https://github.com/darioush)), Ceyhun Onur ([@ceyonur](https://github.com/ceyonur)) |
-| **Status** | Proposed ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/139)) |
+| **Status** | Implementable ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/139)) |
 | **Track** | Standards, Subnet |
 
 ## Abstract


### PR DESCRIPTION
Marking ACP 131 implementable prior to Etna activation as the code is ready in the reference client (avalanchego, coreth, subnet-evm)