### PR TITLE
[ACP-103] - Update to exclude X-Chain

### DIFF
--- a/ACPs/103-dynamic-fees/README.md
+++ b/ACPs/103-dynamic-fees/README.md
@@ -1,13 +1,13 @@
 | ACP | 103 |
 | :--- | :--- |
-| **Title** | Add Dynamic Fees to the X-Chain and P-Chain |
+| **Title** | Add Dynamic Fees to the P-Chain |
 | **Author(s)** | Dhruba Basu ([@dhrubabasu](https://github.com/dhrubabasu)), Alberto Benegiamo ([@abi87](https://github.com/abi87)), Stephen Buttolph ([@StephenButtolph](https://github.com/StephenButtolph)) |
 | **Status** | Proposed ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/104)) |
 | **Track** | Standards |
 
 ## Abstract
 
-Introduce a dynamic fee mechanism to the X-Chain and the P-Chain. Preview a future transition to a multidimensional fee mechanism.
+Introduce a dynamic fee mechanism to the P-Chain. Preview a future transition to a multidimensional fee mechanism.
 
 ## Motivation
 
@@ -17,7 +17,9 @@ With a fixed fee mechanism, users are provided with simplicity and predictabilit
 
 The C-Chain, in [Apricot Phase 3](https://medium.com/avalancheavax/apricot-phase-three-c-chain-dynamic-fees-432d32d67b60), employs a dynamic fee mechanism to raise the price during periods of high demand and lowering the price during periods of low demand. As the price gets too expensive, network utilization will decrease, which drops the price. This ensures the execution and inclusion fee of transactions closely matches the market clearing price.
 
-The X-Chain and P-Chain currently operate under a fixed fee mechanism. To more robustly handle spikes in load, they should be migrated to a dynamic fee mechanism.
+The P-Chain currently operates under a fixed fee mechanism. To more robustly handle spikes in load expected from introducing the improvements in [ACP-77](../77-reinventing-subnets/README.md), it should be migrated to a dynamic fee mechanism. 
+
+The X-Chain also currently operates under a fixed fee mechanism. However, due to the current lower usage and lack of new feature introduction, the migration of the X-Chain to a dynamic fee mechanism is deferred to a later ACP to reduce unnecessary additional technical complexity.
 
 ## Specification
 
@@ -102,13 +104,13 @@ A block gas limit does not need to be set as it is implicitly derived from $r$.
 
 The parameters at activation are:
 
-| Parameter | X-Chain | P-Chain |
+| Parameter | P-Chain |
 | - | - | - |
-| $T$ - target gas consumed per second | TODO | TODO |
-| $M$ - minimum gas price | TODO | TODO |
-| $K$ - gas price update constant | TODO | TODO |
-| $L$ - gas limit constant | TODO | TODO |
-| $S$ - gas limit time period | TODO | TODO |
+| $T$ - target gas consumed per second | TODO |
+| $M$ - minimum gas price | TODO |
+| $K$ - gas price update constant | TODO |
+| $L$ - gas limit constant | TODO |
+| $S$ - gas limit time period | TODO |
 
 As the network gains capacity to handle additional load, this algorithm can be tuned to increase the gas consumption rate.
 
@@ -132,15 +134,15 @@ Assume $b_n = 100$ and the current block is 1 unit above target utilization, or 
 
 ### Block Building Procedure
 
-When a transaction is constructed on the X-Chain and P-Chain, the amount of $AVAX burned is given by `sum($AVAX outputs) - sum($AVAX inputs)`. The amount of gas consumed by the transaction can be deterministically calculated after construction. Dividing the amount of $AVAX burned by the amount of gas consumed yields the maximum gas price that the transaction can pay.
+When a transaction is constructed on the P-Chain, the amount of $AVAX burned is given by `sum($AVAX outputs) - sum($AVAX inputs)`. The amount of gas consumed by the transaction can be deterministically calculated after construction. Dividing the amount of $AVAX burned by the amount of gas consumed yields the maximum gas price that the transaction can pay.
 
-Instead of using a FIFO queue for the mempool (like the X-Chain and P-Chain do now), the mempool should use a priority queue ordered by the maximum gas price of each transaction. This ensures that higher paying transactions are included first.
+Instead of using a FIFO queue for the mempool (like the P-Chain does now), the mempool should use a priority queue ordered by the maximum gas price of each transaction. This ensures that higher paying transactions are included first.
 
 ## Backwards Compatibility
 
 Modification of a fee mechanism is an execution change and requires a mandatory upgrade for activation. Implementers must take care to not alter the execution behavior prior to activation.
 
-After this ACP is activated, any transaction issued on the P-Chain or X-Chain must account for the fee mechanism defined above. Users are responsible for reconstructing their transactions to include a larger fee for quicker inclusion when the fee increases.
+After this ACP is activated, any transaction issued on the P-Chain must account for the fee mechanism defined above. Users are responsible for reconstructing their transactions to include a larger fee for quicker inclusion when the fee increases.
 
 ## Reference Implementation
 
@@ -148,7 +150,7 @@ A full reference implementation has not been provided yet. It must be provided p
 
 ## Security Considerations
 
-The current fixed fee mechanism on the X-Chain and P-Chain does not robustly handle spikes in load. Migrating these chains to a dynamic fee mechanism will ensure that load is properly priced given allotted processing capacity.
+The current fixed fee mechanism on the X-Chain and P-Chain does not robustly handle spikes in load. Migrating the P-Chain to a dynamic fee mechanism will ensure that any additional load caused by demand for new P-Chain features (such as those introduced in [ACP-77](../77-reinventing-subnets/README.md)) is properly priced given allotted processing capacity. The X-Chain, in comparison, currently has significantly lower usage, making it less likely for the demand for blockspace on it to exceed the current static fee rates. If necessary or desired, a future ACP can reuse the mechanism introduced here to add dynamic fee rates to the X-Chain.
 
 ## Acknowledgements
 

--- a/ACPs/103-dynamic-fees/README.md
+++ b/ACPs/103-dynamic-fees/README.md
@@ -104,8 +104,8 @@ A block gas limit does not need to be set as it is implicitly derived from $r$.
 
 The parameters at activation are:
 
-| Parameter | P-Chain |
-| - | - | - |
+| Parameter | P-Chain Configuration|
+| - | - |
 | $T$ - target gas consumed per second | TODO |
 | $M$ - minimum gas price | TODO |
 | $K$ - gas price update constant | TODO |


### PR DESCRIPTION
Given the current low usage of the X-Chain and lack of new feature introduction on it, it is unlikely for demand for blockspace on it to exceed the current static transaction fee costs. Because of this, it is less of a priority to introduce dynamic fee rates on it, and the technical complexity of doing can be avoided until it is necessary.