### PR TITLE
Mark ACP-113 as stale

### DIFF
--- a/ACPs/113-provable-randomness/README.md
+++ b/ACPs/113-provable-randomness/README.md
@@ -2,9 +2,28 @@
 | :------------ | :------------------------------------------------------------------------------------ |
 | **Title**     | Provable Virtual Machine Randomness                                                   |
 | **Author(s)** | Tsachi Herman <http://github.com/tsachiherman>                                        |
-| **Status**    | Proposed ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/142)) |
+| **Status**    | Stale ([Discussion](https://github.com/avalanche-foundation/ACPs/discussions/142)) |
 | **Track**     | Standards                                                                             |
 
+## Future Work
+
+This ACP was marked as stale due to its documented security concerns.
+
+In order to safely utilize randomness produced by this mechanism, the consumer of the randomness must:
+
+1. Define a security threshold `x` which is the maximum number of consecutive blocks which can be proposed by a malicious entity.
+2. After committing to a request for randomness, the consumer must wait for `x` blocks.
+3. After waiting for `x` blocks, the consumer must verify that the randomness was not biased during the `x` blocks.
+4. If the randomness was biased, it insufficient to request randomness again, as this would allow the malicious block producer to discard randomness that it did not like. The consumer of randomness must be able to terminate the request for randomness in such a way that no participant would desire the outcome. However, potential griefing attacks would result from such a construction.
+
+There are alternative mechanisms that would not result in such concerns.
+
+- Utilizing a deterministic threshold signature scheme to finalize a block in consensus would allow the threshold signature to be used during the execution of the block.
+- Utilizing threshold commit-reveal schemes that guarantee that committed values will always be revealed timely.
+
+However, these mechanisms are likely too costly to be introduced into the Avalanche Primary Network due to its validator set size.
+
+It is left to a future ACP to specify the implementation of one of these alternative schemes for smaller sized L1s.
 
 ## Abstract
 


### PR DESCRIPTION
ACP-113 has generated a great amount of conversation and excitement. However, it's security concerns seem to overshadow the usefulness.

This documents the requirements for a correct user to use the construction as documented and marks the ACP as stale.

I'm still highly interested and excited to introduce a highly robust VRF into the Avalanche ecosystem. But it seems like there is still additional work that needs to be done prior to such an event.