### PR TITLE
[ACP-99] Emit Justification Info

### DIFF
--- a/ACPs/99-validatorsetmanager-contract/README.md
+++ b/ACPs/99-validatorsetmanager-contract/README.md
@@ -249,6 +249,7 @@ abstract contract ACP99Manager {
      * Emits a {CompletedValidatorRemoval} on success.
      *
      * @param messageIndex The index of the RegisterL1ValidatorMessage.
+     * @return validationID The ID of the validator that was removed.
      */
     function completeValidatorRemoval(uint32 messageIndex)
         public

--- a/ACPs/99-validatorsetmanager-contract/README.md
+++ b/ACPs/99-validatorsetmanager-contract/README.md
@@ -171,11 +171,9 @@ abstract contract ACP99Manager {
     function subnetID() public view virtual returns (bytes32 id);
 
     /// @notice Returns the validator details for a given validation ID.
-    function getValidator(bytes32 validationID)
-        public
-        view
-        virtual
-        returns (Validator memory validator);
+    function getValidator(
+        bytes32 validationID
+    ) public view virtual returns (Validator memory validator);
 
     /// @notice Returns the total weight of the current L1 validator set.
     function l1TotalWeight() public view virtual returns (uint64 weight);
@@ -227,10 +225,9 @@ abstract contract ACP99Manager {
      * @param messageIndex The index of the L1ValidatorRegistrationMessage to be received providing the acknowledgement.
      * @return validationID The ID of the registered validator.
      */
-    function completeValidatorRegistration(uint32 messageIndex)
-        public
-        virtual
-        returns (bytes32 validationID);
+    function completeValidatorRegistration(
+        uint32 messageIndex
+    ) public virtual returns (bytes32 validationID);
 
     /**
      * @notice Initiates validator removal by issuing a L1ValidatorWeightMessage with the weight set to zero.
@@ -240,7 +237,9 @@ abstract contract ACP99Manager {
      *
      * @param validationID The ID of the validator to remove.
      */
-    function _initiateValidatorRemoval(bytes32 validationID) internal virtual;
+    function _initiateValidatorRemoval(
+        bytes32 validationID
+    ) internal virtual;
 
     /**
      * @notice Completes validator removal by consuming an RegisterL1ValidatorMessage from the P-Chain acknowledging
@@ -251,10 +250,9 @@ abstract contract ACP99Manager {
      * @param messageIndex The index of the RegisterL1ValidatorMessage.
      * @return validationID The ID of the validator that was removed.
      */
-    function completeValidatorRemoval(uint32 messageIndex)
-        public
-        virtual
-        returns (bytes32 validationID);
+    function completeValidatorRemoval(
+        uint32 messageIndex
+    ) public virtual returns (bytes32 validationID);
 
     /**
      * @notice Initiates a validator weight update by issuing an L1ValidatorWeightMessage with a nonzero weight.
@@ -282,10 +280,9 @@ abstract contract ACP99Manager {
      * @return validationID The ID of the validator, retreived from the L1ValidatorWeightMessage.
      * @return nonce The nonce of the validator, retreived from the L1ValidatorWeightMessage.
      */
-    function completeValidatorWeightUpdate(uint32 messageIndex)
-        public
-        virtual
-        returns (bytes32 validationID, uint64 nonce);
+    function completeValidatorWeightUpdate(
+        uint32 messageIndex
+    ) public virtual returns (bytes32 validationID, uint64 nonce);
 }
 ```
 

--- a/ACPs/99-validatorsetmanager-contract/README.md
+++ b/ACPs/99-validatorsetmanager-contract/README.md
@@ -120,15 +120,34 @@ For a full implementation, please see the [Reference Implementation](#reference-
  * validator management, as specified in ACP-77.
  */
 abstract contract ACP99Manager {
-    /// @notice Emitted when an initial validator is registered.
-    event RegisteredInitialValidator(bytes32 indexed validationID, bytes20 indexed nodeID, uint64 weight);
-    /// @notice Emitted when a validator registration to the L1 is initiated.
+    /**
+     * @notice Emitted when an initial validator is registered.
+     * @notice The field index is the index of the initial validator in the conversion data.
+     * This is used along with the subnetID as the ACP-118 justification for
+     * signature requests from P-Chain validators over a L1ValidatorRegistrationMessage
+     * when removing the validator
+     */
+    event RegisteredInitialValidator(
+        bytes32 indexed validationID,
+        bytes20 indexed nodeID,
+        bytes32 indexed subnetID,
+        uint64 weight,
+        uint32 index
+    );
+    /**
+     * @notice Emitted when a validator registration to the L1 is initiated.
+     * @notice The field registerL1ValidatorMessage is the serialized RegisterL1ValidatorMessage
+     * used to register the validator on the P-Chain. This is also used as the
+     * ACP-118 justification for signature requests from P-Chain validators
+     * over a L1ValidatorRegistrationMessage when removing the validator.
+     */
     event InitiatedValidatorRegistration(
         bytes32 indexed validationID,
         bytes20 indexed nodeID,
         bytes32 registrationMessageID,
         uint64 registrationExpiry,
-        uint64 weight
+        uint64 weight,
+        bytes registerL1ValidatorMessage
     );
     /// @notice Emitted when a validator registration to the L1 is completed.
     event CompletedValidatorRegistration(bytes32 indexed validationID, uint64 weight);


### PR DESCRIPTION
- Adds information needed to construct ACP-118 justifications for ACP-77 ICM message types to be signed by P-Chain validators. See https://github.com/ava-labs/icm-contracts/pull/741 for expanded context.
- Adds a missing NatSpec comment
- Formats Solidity code blocks using the stable Foundry v1.0.0 release