### PR TITLE
[ACP-194] SAE: Simplify Delta t assignment

### DIFF
--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -429,6 +429,7 @@ Thank you to the following non-exhaustive list of individuals for input, discuss
 
 * [Aaron Buchwald](https://github.com/aaronbuchwald)
 * [Angharad Thomas](https://x.com/divergenceharri)
+* [Martin Eckardt](https://github.com/martineckardt)
 * [Meaghan FitzGerald](https://github.com/meaghanfitzgerald)
 * [Michael Kaplan](https://github.com/michaelkaplan13)
 * [Yacov Manevich](https://github.com/yacovm)


### PR DESCRIPTION
Replaced the original expression `Δt := max(te, tb) − te` with the simplified and equivalent form `Δt := max(0, tb − te)`. This improves clarity by directly expressing the non-negative delay between tb and te, and avoids unnecessary use of `max(te, tb)`.