### PR TITLE
update rip-7212 with eip-7951

### DIFF
--- a/ACPs/204-precompile-secp256r1/README.md
+++ b/ACPs/204-precompile-secp256r1/README.md
@@ -21,7 +21,7 @@ This ACP proposes implementing EIP-7951's secp256r1 precompiled contract to unlo
 
 - Reduced onboarding friction: Enterprises can leverage existing biometric authentication infrastructure instead of managing seed phrases or hardware wallets
 - Regulatory compliance: Institutions can utilize their approved device security standards and identity management systems
-- Cost optimization: 100x gas reduction (from 200k-330k to 6,900 gas) makes enterprise-scale applications economically viable
+- Cost optimization: ~50x gas reduction (from 200k-330k to 6,900 gas) makes enterprise-scale applications economically viable
 
 The 100x gas cost reduction makes these use cases economically viable while maintaining the security properties institutions and users expect from their existing devices. 
 


### PR DESCRIPTION
[RIP-7212](https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md) is superseded by [EIP-7951](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7951.md) due to some security vulnerabilities discovered. Go-ethereum already implemented and merged the EIP. 

There seems no issue of compatibility other than increased gas cost (3450 in 7212 vs 6900 in 7951)

EIP-7951 is still in status: Draft, but I think it will eventually supersedes 7212.