### PR TITLE
[ACP-226] minimumBlockDelayExcess and gas capacity added per millisecond.

### DIFF
--- a/ACPs/226-dynamic-minimum-block-times/README.md
+++ b/ACPs/226-dynamic-minimum-block-times/README.md
@@ -39,7 +39,7 @@ The new `minimumBlockDelayExcess` field in the block header will be used to deri
 
 The `minimumBlockDelayExcess` field will be represented in block headers as a `uint64`.
 
-The value of `minimumBlockDelayExcess` can be updated in each block, similar to the target excess field introduced in ACP-176. The mechanism is specified below.
+The value of `minimumBlockDelayExcess` can be updated in each block, similar to the gas target excess field introduced in ACP-176. The mechanism is specified below.
 
 ### Dynamic `minimumBlockDelay` mechanism
 

--- a/ACPs/226-dynamic-minimum-block-times/README.md
+++ b/ACPs/226-dynamic-minimum-block-times/README.md
@@ -75,9 +75,9 @@ As $q$ is updated after the execution of transactions within the block, $m$ is a
 
 ### Gas Accounting Updates
 
-Currently, the amount of gas capacity available is only incremented on a per second basis, as defined by ACP-176. With this ACP, it is expected for chains to be able to have sub-second block times. However, in the case when a chain's gas capacity is full consumed (i.e. during period of heavy transaction load), blocks would not be able to produced at sub-second intervals because at least one second would need to elapse for new gas capacity to be added. To correct this, upon activation of this ACP, gas capacity will be added on a per millisecond basis.
+Currently, the amount of gas capacity available is only incremented on a per second basis, as defined by ACP-176. With this ACP, it is expected for chains to be able to have sub-second block times. However, in the case when a chain's gas capacity is fully consumed (i.e. during period of heavy transaction load), blocks would not be able to produced at sub-second intervals because at least one second would need to elapse for new gas capacity to be added. To correct this, upon activation of this ACP, gas capacity will be added on a per millisecond basis.
 
-The ACP-176 mechanism for determing the target gas consumption per second will remain unchanged, but will now be used to derive the target gas consumption per millisecond by dividing by 1000, and gas capacity will be added at that rate as each block advances time by some number of milliseconds.
+The ACP-176 mechanism for determing the target gas consumption per second will remain unchanged, but its result will now be used to derive the target gas consumption per millisecond by dividing by 1000, and gas capacity will be added at that rate as each block advances time by some number of milliseconds.
 
 ### Activation Parameters for the C-Chain
 

--- a/ACPs/226-dynamic-minimum-block-times/README.md
+++ b/ACPs/226-dynamic-minimum-block-times/README.md
@@ -35,7 +35,7 @@ The `timestampMilliseconds` field will be represented in block headers as a `uin
 
 #### `minimumBlockDelayExcess`
 
-The new `minimumBlockDelayExcess` field in the block header will be used to derive the minimum number of milliseconds that must pass before the next block is allowed to be accepted. Specifically, if block $B$ has a `minimumBlockDelayExcess` of $q$, then the effective timestamp of block $B+1$ in milliseconds must be at least $ M * e^{\frac{q}{D}} $ greater than the effective timestamp of block $B$ in milliseconds. $M$, $q$, and $D$ are defined below in the mechanism specification.
+The new `minimumBlockDelayExcess` field in the block header will be used to derive the minimum number of milliseconds that must pass before the next block is allowed to be accepted. Specifically, if block $B$ has a `minimumBlockDelayExcess` of $q$, then the effective timestamp of block $B+1$ in milliseconds must be at least $M * e^{\frac{q}{D}}$ greater than the effective timestamp of block $B$ in milliseconds. $M$, $q$, and $D$ are defined below in the mechanism specification.
 
 The `minimumBlockDelayExcess` field will be represented in block headers as a `uint64`.
 


### PR DESCRIPTION
This PR updates the ACP-226 specification with updates discussed on the community call on August 28th.

Specifically, the block headers will have `minimumBlockDelayExcess` field rather than `minimumBlockDelay`, and gas capacity will be added on a per millisecond basis to allow for sub-second block production even when a chain's gas capacity is fully consumed.