### PR TITLE
ACP-292: C-Chain-First EVM Contract Code Size Increase with Avalanche L1 Customizability

### DIFF
--- a/ACPs/000-configurable-evm-code-size-limit/README.md
+++ b/ACPs/000-configurable-evm-code-size-limit/README.md
@@ -1,0 +1,159 @@
+| ACP | TBD |
+| :--- | :--- |
+| **Title** | Configurable EVM Contract Code Size Limit for Avalanche L1s |
+| **Author(s)** | Giacomo Barbieri [(@ijaack94)](https://x.com/ijaack94) |
+| **Status** | Proposed |
+| **Track** | Standards |
+
+## Abstract
+
+This ACP proposes making the maximum deployed EVM contract code size configurable for Avalanche L1s that run Subnet-EVM-compatible execution environments. Today, Avalanche L1s inherit Ethereum's fixed runtime bytecode limit introduced by EIP-170 (24,576 bytes), as well as the corresponding initcode ceiling introduced by EIP-3860. While these defaults preserve Ethereum compatibility, they unnecessarily constrain Avalanche L1s whose validator sets are willing to accept larger contract artifacts in exchange for simpler application architecture, fewer proxy splits, and less deployment fragmentation.
+
+Under this ACP, Avalanche L1s MAY configure a higher consensus-level `maxCodeSize`, while preserving the Ethereum default when no override is specified. The associated initcode limit MUST scale accordingly so deployments remain internally consistent. This ACP does not change opcode semantics, gas accounting, or C-Chain behavior by default. Instead, it gives Avalanche L1s an explicit, opt-in configurability surface for bytecode size limits, allowing each network to choose its own balance between compatibility, performance, and developer ergonomics.
+
+## Motivation
+
+Avalanche's value proposition is not strict uniformity with Ethereum at all layers; it is configurable execution environments with credible validator-enforced rules. The EIP-170 contract size limit is a reasonable default for generalized EVM networks, but it is still a policy choice rather than a law of nature.
+
+Several application teams want to deploy larger contracts for reasons that are operationally rational:
+
+- complex applications may prefer fewer contract boundaries and fewer proxy patterns;
+- security reviews are sometimes easier on a single coherent artifact than on a heavily fragmented deployment;
+- some chains optimize for app-specific throughput or controlled validator sets rather than maximal bytecode portability;
+- a strict Ethereum-sized cap can force unnecessary engineering workarounds on Avalanche L1s even when their validators are comfortable accepting the tradeoff.
+
+Recent market examples, including Robinhood's reported support for materially larger contracts than Ethereum, show that EVM builders increasingly view code-size policy as a chain-level design parameter. Avalanche should support the same flexibility where it fits the chain operator's goals.
+
+At the same time, a blanket increase on the Avalanche C-Chain would be harder to justify because it changes network-wide expectations for the most Ethereum-like Avalanche environment. This ACP therefore focuses on the cleaner and more Avalanche-native step first: make the limit configurable for Avalanche L1s, keep the default unchanged, and let validators opt in deliberately.
+
+## Specification
+
+### 1. Scope
+
+This ACP applies to Avalanche L1s that run Subnet-EVM-compatible execution environments.
+
+This ACP does **not** change the C-Chain default contract size limit or initcode limit. A future ACP MAY propose enabling a different limit on the C-Chain, but that is outside the scope of this proposal.
+
+### 2. New Consensus Parameters
+
+Subnet-EVM-compatible Avalanche L1s MUST support the following consensus parameters:
+
+- `maxCodeSize`: maximum number of bytes permitted for deployed runtime bytecode.
+- `maxInitCodeSize`: maximum number of bytes permitted for initcode during contract creation.
+
+If these parameters are not explicitly configured, implementations MUST preserve Ethereum-compatible defaults:
+
+- `maxCodeSize = 24,576` bytes
+- `maxInitCodeSize = 49,152` bytes
+
+These values correspond to the existing EIP-170 and EIP-3860 defaults.
+
+### 3. Configuration Rules
+
+`maxCodeSize` and `maxInitCodeSize` are consensus parameters and therefore MUST be identical across all validating nodes for a given Avalanche L1.
+
+An Avalanche L1 MAY set these parameters:
+
+- in genesis at chain launch; or
+- in a coordinated network upgrade activated at a specific timestamp.
+
+If `maxCodeSize` is explicitly set and `maxInitCodeSize` is omitted, `maxInitCodeSize` MUST default to `2 * maxCodeSize`.
+
+Implementations MAY reject configurations where:
+
+- `maxCodeSize < 24,576` bytes;
+- `maxInitCodeSize < maxCodeSize`; or
+- `maxInitCodeSize != 2 * maxCodeSize`, if the implementation chooses to enforce a fixed ratio for simplicity.
+
+To maximize interoperability across Avalanche L1 tooling, reference implementations should initially enforce:
+
+- `24,576 <= maxCodeSize <= 98,304`
+- `maxInitCodeSize = 2 * maxCodeSize`
+
+This gives Avalanche L1s up to 4x Ethereum's deployed-code limit while keeping the parameter surface narrow and predictable.
+
+### 4. Contract Creation Semantics
+
+For `CREATE` and `CREATE2`:
+
+- if the resulting runtime bytecode exceeds `maxCodeSize`, contract creation MUST fail;
+- if the supplied initcode exceeds `maxInitCodeSize`, contract creation MUST fail.
+
+No other EVM execution semantics are changed by this ACP.
+
+In particular:
+
+- opcode behavior is unchanged;
+- code deposit gas remains unchanged;
+- existing gas metering for initcode analysis remains unchanged unless separately modified by a future ACP.
+
+### 5. RPC and Tooling Exposure
+
+Implementations SHOULD expose the active `maxCodeSize` and `maxInitCodeSize` values through chain configuration inspection endpoints, client configuration output, or both, so that explorers, SDKs, deployment tooling, and auditors can determine the active deployment constraints of a given Avalanche L1.
+
+### 6. Activation Requirements
+
+Any network upgrade that changes `maxCodeSize` or `maxInitCodeSize` MUST clearly specify:
+
+- activation timestamp;
+- old and new values;
+- whether previously failing deployments are expected to become valid after activation.
+
+Previously deployed contracts are unaffected. Only contract creation validity after activation changes.
+
+## Backwards Compatibility
+
+This ACP is backwards compatible by default because chains that do not opt in retain Ethereum-compatible defaults.
+
+For Avalanche L1s that do opt in, the main compatibility impact is positive but chain-specific: contracts that would previously fail deployment due to EIP-170/EIP-3860-sized limits may deploy successfully after activation.
+
+Potential compatibility considerations include:
+
+- deployment tools may assume Ethereum's 24,576-byte runtime limit;
+- explorers, static analyzers, and indexers may have hardcoded assumptions around EIP-170-sized artifacts;
+- bridges, wallets, and SDKs that market themselves as “Ethereum-compatible” may need to clarify that compatibility does not imply Ethereum-identical code-size policy.
+
+Because this ACP only relaxes deployment constraints for opt-in Avalanche L1s, ordinary transaction execution and already-deployed contracts remain unaffected.
+
+## Reference Implementation
+
+A reference implementation is not yet provided.
+
+A compliant implementation should:
+
+1. add `maxCodeSize` and `maxInitCodeSize` as explicit consensus parameters in Subnet-EVM-compatible configuration;
+2. validate those parameters during genesis parsing and network-upgrade activation;
+3. apply the configured values in contract creation checks for `CREATE` and `CREATE2`;
+4. expose the configured values through operator-facing or tooling-facing interfaces; and
+5. include local-network telemetry comparing contract deployment latency, block-building behavior, and state growth at multiple size thresholds.
+
+## Security Considerations
+
+Larger deployable contracts increase worst-case resource usage during contract creation, code dissemination, and downstream tooling analysis. This does not automatically make larger limits unsafe, but it does make the tradeoff explicit.
+
+Relevant risks include:
+
+- **Block construction and verification cost:** larger contract artifacts may increase block processing and propagation time.
+- **State growth:** larger bytecode blobs increase long-term state footprint.
+- **Tooling fragility:** off-chain systems may silently assume Ethereum-sized artifacts.
+- **DoS surface:** chains that raise limits too aggressively may increase the cost asymmetry between deployers and validators if other guardrails are not sufficient.
+
+These risks are why this ACP proposes:
+
+- opt-in L1 configurability rather than a blanket network-wide increase;
+- unchanged Ethereum-compatible defaults;
+- a narrow initial recommended range capped at 4x Ethereum's default; and
+- explicit visibility of active limits for operators and tooling.
+
+Any Avalanche L1 adopting a higher limit should benchmark deployment latency, block propagation, and archival/storage implications before activation.
+
+## Open Questions
+
+- Should the initial interoperable range be capped at 4x Ethereum's default, or should implementations permit a wider range from day one?
+- Should C-Chain eventually expose the same configurability, or should this remain an Avalanche L1-only feature?
+- Should tooling-facing RPC standardization be part of this ACP, or left to implementation-specific documentation?
+- Should future work pair larger code-size limits with additional deployment gas or other anti-DoS guardrails?
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/ACPs/000-configurable-evm-code-size-limit/README.md
+++ b/ACPs/000-configurable-evm-code-size-limit/README.md
@@ -26,6 +26,8 @@ Several application teams want to deploy larger contracts for reasons that are o
 
 Recent market examples, including Robinhood's reported support for materially larger contracts than Ethereum, show that code-size policy is increasingly a competitive chain feature rather than just a low-level implementation detail.
 
+Fresh on-chain sampling also suggests the current EIP-170 ceiling is a binding constraint in active EVM environments rather than a merely theoretical one. In a 2026-07-04 sample of the most recent 2,000 Base blocks, there were 217 successful contract creations. Of those deployments, 12 produced runtime bytecode of at least 22,000 bytes, 11 were at least 23,000 bytes, and 4 were at least 24,000 bytes. The largest observed runtime artifacts were 24,561 bytes, only 15 bytes below Ethereum's 24,576-byte cap. This is strong evidence that builders already ship directly against the existing ceiling when chain activity is high. A contemporaneous recent C-Chain sample showed much lower contract-creation volume, so the cleaner empirical signal comes from broader EVM deployment behavior rather than recent Avalanche-only flow.
+
 Making the C-Chain the first mover does two things:
 
 1. it gives Avalanche's flagship EVM environment a stronger builder proposition immediately; and

--- a/ACPs/000-configurable-evm-code-size-limit/README.md
+++ b/ACPs/000-configurable-evm-code-size-limit/README.md
@@ -139,7 +139,12 @@ Potential compatibility considerations across both environments include:
 
 ## Reference Implementation
 
-A reference implementation is not yet provided.
+The reference implementation for this ACP is split across two codebases:
+
+- **Coreth (C-Chain):** a network upgrade that activates `maxCodeSize = 49,152` and `maxInitCodeSize = 98,304` on the C-Chain, and threads those activated values through the existing EIP-170/EIP-3860 enforcement points in `core/state_transition.go`, `core/txpool/validation.go`, and `sync/client/client.go`, with matching coverage in `core/state_processor_test.go`, `sync/client/client_test.go`, and `params/protocol_params_test.go`.
+- **Subnet-EVM (Avalanche L1s):** explicit `maxCodeSize` and `maxInitCodeSize` consensus parameters in chain configuration and upgrade parsing, validation at genesis and upgrade time, `maxInitCodeSize = 2 * maxCodeSize` defaulting when omitted, and enforcement through the same contract creation, txpool, and sync code paths. The implementation naturally touches `params/extras/config.go`, `params/config_extra.go`, `core/genesis.go`, `core/state_transition.go`, `core/txpool/validation.go`, and `sync/client/client.go`, with corresponding tests.
+
+Together, these changes provide the full reference implementation: Coreth demonstrates the C-Chain-first activation path, while Subnet-EVM demonstrates the Avalanche L1 customizability surface.
 
 A compliant implementation should:
 

--- a/ACPs/000-configurable-evm-code-size-limit/README.md
+++ b/ACPs/000-configurable-evm-code-size-limit/README.md
@@ -1,38 +1,50 @@
 | ACP | TBD |
 | :--- | :--- |
-| **Title** | Configurable EVM Contract Code Size Limit for Avalanche L1s |
+| **Title** | C-Chain-First EVM Contract Code Size Increase with Avalanche L1 Customizability |
 | **Author(s)** | Giacomo Barbieri [(@ijaack94)](https://x.com/ijaack94) |
 | **Status** | Proposed |
 | **Track** | Standards |
 
 ## Abstract
 
-This ACP proposes making the maximum deployed EVM contract code size configurable for Avalanche L1s that run Subnet-EVM-compatible execution environments. Today, Avalanche L1s inherit Ethereum's fixed runtime bytecode limit introduced by EIP-170 (24,576 bytes), as well as the corresponding initcode ceiling introduced by EIP-3860. While these defaults preserve Ethereum compatibility, they unnecessarily constrain Avalanche L1s whose validator sets are willing to accept larger contract artifacts in exchange for simpler application architecture, fewer proxy splits, and less deployment fragmentation.
+This ACP proposes a C-Chain-first increase to the maximum deployed EVM contract code size, while also making the same limit configurable for Avalanche L1s that run Subnet-EVM-compatible execution environments. Today, both environments inherit Ethereum's fixed runtime bytecode limit introduced by EIP-170 (24,576 bytes), as well as the corresponding initcode ceiling introduced by EIP-3860. Those defaults preserve Ethereum compatibility, but they can unnecessarily constrain Avalanche builders who prefer larger contract artifacts in exchange for simpler application architecture, fewer proxy splits, and less deployment fragmentation.
 
-Under this ACP, Avalanche L1s MAY configure a higher consensus-level `maxCodeSize`, while preserving the Ethereum default when no override is specified. The associated initcode limit MUST scale accordingly so deployments remain internally consistent. This ACP does not change opcode semantics, gas accounting, or C-Chain behavior by default. Instead, it gives Avalanche L1s an explicit, opt-in configurability surface for bytecode size limits, allowing each network to choose its own balance between compatibility, performance, and developer ergonomics.
+Under this ACP, the Avalanche C-Chain default `maxCodeSize` is increased to `49,152` bytes, with `maxInitCodeSize` increased proportionally to `98,304` bytes. Avalanche L1s MUST support configurable `maxCodeSize` and `maxInitCodeSize` consensus parameters, allowing each network to preserve Ethereum defaults, match the C-Chain, or choose another supported value. This ACP does not change opcode semantics or core gas accounting. Instead, it makes code-size policy an explicit Avalanche design surface: C-Chain moves first, and Avalanche L1s retain customizability.
 
 ## Motivation
 
-Avalanche's value proposition is not strict uniformity with Ethereum at all layers; it is configurable execution environments with credible validator-enforced rules. The EIP-170 contract size limit is a reasonable default for generalized EVM networks, but it is still a policy choice rather than a law of nature.
+Avalanche should not treat Ethereum's bytecode-size limit as immutable when the constraint is materially affecting real builder behavior. The EIP-170 contract size limit is a policy choice optimized for Ethereum's historical tradeoffs, not a universal optimum for all EVM environments.
+
+This proposal takes the position that Avalanche should lead on the C-Chain first.
 
 Several application teams want to deploy larger contracts for reasons that are operationally rational:
 
 - complex applications may prefer fewer contract boundaries and fewer proxy patterns;
 - security reviews are sometimes easier on a single coherent artifact than on a heavily fragmented deployment;
-- some chains optimize for app-specific throughput or controlled validator sets rather than maximal bytecode portability;
-- a strict Ethereum-sized cap can force unnecessary engineering workarounds on Avalanche L1s even when their validators are comfortable accepting the tradeoff.
+- bytecode fragmentation can add engineering and auditing overhead without improving application logic;
+- Avalanche is well positioned to compete for builders who want a more permissive, but still well-guarded, EVM environment.
 
-Recent market examples, including Robinhood's reported support for materially larger contracts than Ethereum, show that EVM builders increasingly view code-size policy as a chain-level design parameter. Avalanche should support the same flexibility where it fits the chain operator's goals.
+Recent market examples, including Robinhood's reported support for materially larger contracts than Ethereum, show that code-size policy is increasingly a competitive chain feature rather than just a low-level implementation detail.
 
-At the same time, a blanket increase on the Avalanche C-Chain would be harder to justify because it changes network-wide expectations for the most Ethereum-like Avalanche environment. This ACP therefore focuses on the cleaner and more Avalanche-native step first: make the limit configurable for Avalanche L1s, keep the default unchanged, and let validators opt in deliberately.
+Making the C-Chain the first mover does two things:
+
+1. it gives Avalanche's flagship EVM environment a stronger builder proposition immediately; and
+2. it establishes a clean precedent for Avalanche L1s to customize the same parameter according to their own validator and application requirements.
+
+Avalanche L1 customizability still matters. Some L1s may want to retain Ethereum defaults for strict compatibility, while others may want to match or exceed the C-Chain limit. This ACP therefore pairs a C-Chain-first default increase with an explicit L1 configuration surface rather than forcing a single network-wide policy everywhere.
 
 ## Specification
 
 ### 1. Scope
 
-This ACP applies to Avalanche L1s that run Subnet-EVM-compatible execution environments.
+This ACP applies to:
 
-This ACP does **not** change the C-Chain default contract size limit or initcode limit. A future ACP MAY propose enabling a different limit on the C-Chain, but that is outside the scope of this proposal.
+- the Avalanche C-Chain; and
+- Avalanche L1s that run Subnet-EVM-compatible execution environments.
+
+On the C-Chain, this ACP increases the default contract size and initcode limits.
+
+On Avalanche L1s, this ACP requires support for configurable contract size and initcode limits through consensus parameters.
 
 ### 2. New Consensus Parameters
 
@@ -41,7 +53,12 @@ Subnet-EVM-compatible Avalanche L1s MUST support the following consensus paramet
 - `maxCodeSize`: maximum number of bytes permitted for deployed runtime bytecode.
 - `maxInitCodeSize`: maximum number of bytes permitted for initcode during contract creation.
 
-If these parameters are not explicitly configured, implementations MUST preserve Ethereum-compatible defaults:
+For the Avalanche C-Chain, the post-activation defaults are:
+
+- `maxCodeSize = 49,152` bytes
+- `maxInitCodeSize = 98,304` bytes
+
+For Avalanche L1s, if these parameters are not explicitly configured, implementations MUST preserve Ethereum-compatible defaults:
 
 - `maxCodeSize = 24,576` bytes
 - `maxInitCodeSize = 49,152` bytes
@@ -52,14 +69,19 @@ These values correspond to the existing EIP-170 and EIP-3860 defaults.
 
 `maxCodeSize` and `maxInitCodeSize` are consensus parameters and therefore MUST be identical across all validating nodes for a given Avalanche L1.
 
-An Avalanche L1 MAY set these parameters:
+The Avalanche C-Chain MUST activate the following values at the upgrade timestamp defined by the implementation:
+
+- `maxCodeSize = 49,152`
+- `maxInitCodeSize = 98,304`
+
+An Avalanche L1 MAY set its own parameters:
 
 - in genesis at chain launch; or
 - in a coordinated network upgrade activated at a specific timestamp.
 
-If `maxCodeSize` is explicitly set and `maxInitCodeSize` is omitted, `maxInitCodeSize` MUST default to `2 * maxCodeSize`.
+If an Avalanche L1 explicitly sets `maxCodeSize` and omits `maxInitCodeSize`, `maxInitCodeSize` MUST default to `2 * maxCodeSize`.
 
-Implementations MAY reject configurations where:
+Implementations MAY reject Avalanche L1 configurations where:
 
 - `maxCodeSize < 24,576` bytes;
 - `maxInitCodeSize < maxCodeSize`; or
@@ -70,7 +92,7 @@ To maximize interoperability across Avalanche L1 tooling, reference implementati
 - `24,576 <= maxCodeSize <= 98,304`
 - `maxInitCodeSize = 2 * maxCodeSize`
 
-This gives Avalanche L1s up to 4x Ethereum's deployed-code limit while keeping the parameter surface narrow and predictable.
+This lets Avalanche L1s preserve Ethereum compatibility, match the C-Chain, or increase further up to 4x Ethereum's deployed-code limit while keeping the parameter surface narrow and predictable.
 
 ### 4. Contract Creation Semantics
 
@@ -103,17 +125,17 @@ Previously deployed contracts are unaffected. Only contract creation validity af
 
 ## Backwards Compatibility
 
-This ACP is backwards compatible by default because chains that do not opt in retain Ethereum-compatible defaults.
+This ACP is not backwards compatible with the pre-upgrade C-Chain deployment limit, because the C-Chain default contract size and initcode limits increase at activation.
 
-For Avalanche L1s that do opt in, the main compatibility impact is positive but chain-specific: contracts that would previously fail deployment due to EIP-170/EIP-3860-sized limits may deploy successfully after activation.
+On the C-Chain, the compatibility impact is limited to contract creation validity after activation: contracts that would previously fail due to EIP-170/EIP-3860-sized limits may deploy successfully after the upgrade. Ordinary execution semantics for already-deployed contracts remain unchanged.
 
-Potential compatibility considerations include:
+For Avalanche L1s, this ACP is backwards compatible by default because chains that do not opt in retain Ethereum-compatible defaults.
+
+Potential compatibility considerations across both environments include:
 
 - deployment tools may assume Ethereum's 24,576-byte runtime limit;
 - explorers, static analyzers, and indexers may have hardcoded assumptions around EIP-170-sized artifacts;
 - bridges, wallets, and SDKs that market themselves as “Ethereum-compatible” may need to clarify that compatibility does not imply Ethereum-identical code-size policy.
-
-Because this ACP only relaxes deployment constraints for opt-in Avalanche L1s, ordinary transaction execution and already-deployed contracts remain unaffected.
 
 ## Reference Implementation
 
@@ -121,11 +143,12 @@ A reference implementation is not yet provided.
 
 A compliant implementation should:
 
-1. add `maxCodeSize` and `maxInitCodeSize` as explicit consensus parameters in Subnet-EVM-compatible configuration;
-2. validate those parameters during genesis parsing and network-upgrade activation;
-3. apply the configured values in contract creation checks for `CREATE` and `CREATE2`;
-4. expose the configured values through operator-facing or tooling-facing interfaces; and
-5. include local-network telemetry comparing contract deployment latency, block-building behavior, and state growth at multiple size thresholds.
+1. increase the C-Chain `maxCodeSize` to `49,152` and `maxInitCodeSize` to `98,304` at a defined upgrade point;
+2. add `maxCodeSize` and `maxInitCodeSize` as explicit consensus parameters in Subnet-EVM-compatible Avalanche L1 configuration;
+3. validate those parameters during genesis parsing and network-upgrade activation;
+4. apply the configured values in contract creation checks for `CREATE` and `CREATE2`;
+5. expose the configured values through operator-facing or tooling-facing interfaces; and
+6. include local-network telemetry comparing contract deployment latency, block-building behavior, and state growth at multiple size thresholds.
 
 ## Security Considerations
 
@@ -140,17 +163,17 @@ Relevant risks include:
 
 These risks are why this ACP proposes:
 
-- opt-in L1 configurability rather than a blanket network-wide increase;
-- unchanged Ethereum-compatible defaults;
-- a narrow initial recommended range capped at 4x Ethereum's default; and
+- a bounded C-Chain increase to 2x Ethereum's default rather than an unbounded jump;
+- explicit Avalanche L1 configurability rather than forcing the C-Chain value everywhere;
+- a narrow initial recommended Avalanche L1 range capped at 4x Ethereum's default; and
 - explicit visibility of active limits for operators and tooling.
 
-Any Avalanche L1 adopting a higher limit should benchmark deployment latency, block propagation, and archival/storage implications before activation.
+The C-Chain upgrade should be benchmarked before activation, and any Avalanche L1 adopting a higher limit should benchmark deployment latency, block propagation, and archival/storage implications before activation.
 
 ## Open Questions
 
-- Should the initial interoperable range be capped at 4x Ethereum's default, or should implementations permit a wider range from day one?
-- Should C-Chain eventually expose the same configurability, or should this remain an Avalanche L1-only feature?
+- Is 2x Ethereum's default the right C-Chain starting point, or should the first C-Chain increase be smaller or larger?
+- Should Avalanche L1 implementations be permitted to exceed 4x Ethereum's default from day one, or should the interoperable range remain tighter initially?
 - Should tooling-facing RPC standardization be part of this ACP, or left to implementation-specific documentation?
 - Should future work pair larger code-size limits with additional deployment gas or other anti-DoS guardrails?
 

--- a/ACPs/292-configurable-evm-code-size-limit/README.md
+++ b/ACPs/292-configurable-evm-code-size-limit/README.md
@@ -1,4 +1,6 @@
-| ACP | TBD |
+# ACP-292: C-Chain-First EVM Contract Code Size Increase with Avalanche L1 Customizability
+
+| ACP | 292 |
 | :--- | :--- |
 | **Title** | C-Chain-First EVM Contract Code Size Increase with Avalanche L1 Customizability |
 | **Author(s)** | Giacomo Barbieri [(@ijaack94)](https://x.com/ijaack94) |


### PR DESCRIPTION
## Summary
- propose a C-Chain-first increase of the deployed EVM contract code size limit to 49,152 bytes
- require Subnet-EVM-compatible Avalanche L1s to support configurable `maxCodeSize` and `maxInitCodeSize` consensus parameters
- include motivation grounded in fresh on-chain deployment data showing recent near-cap contract sizes on active EVM flow

## Included in this draft
- rationale for C-Chain-first positioning
- Avalanche L1 customizability requirements
- reference implementation details for Coreth and Subnet-EVM
