### PR TITLE
[ACP-267] Tie effective date to Helicon activation

### DIFF
--- a/ACPs/267-uptime-requirement-increase/README.md
+++ b/ACPs/267-uptime-requirement-increase/README.md
@@ -41,18 +41,15 @@ The proposed change only raises the validator uptime requirement to 90%, with th
 
 ### Effective Date
 
-The 90% uptime requirement only applies to validations that meet **both** of the following conditions:
+The 90% uptime requirement applies to validations whose staking period **starts on or after the activation of the Helicon network upgrade**.
 
-1. The validation **started on or after April 1, 2026**.
-2. The validation **has not ended before the activation time of the AvalancheGo release implementing this ACP**.
-
-Validations that started before April 1, 2026, or that ended before the activation of this change, continue to be evaluated against the existing 80% uptime threshold.
+Validations that started before Helicon activation continue to be evaluated against the existing 80% uptime threshold.
 
 ## Backwards Compatibility
 
 Each node continuously tracks its perceived uptime of its peers throughout the peer's validator staking period. At the end of the peer's validator staking period, each node sets its preference of whether or not to reward the peer based on its perceived uptime.
 
-The effective date ensures that validators who began their staking period without knowledge of the increased requirement are not retroactively penalized. This ACP was announced on February 10, 2026, and notifications were added in relevant places including the Core staking UI, block explorers, and validator uptime statistics dashboards. The April 1, 2026 effective date provides sufficient lead time for validators to adjust their infrastructure.
+The effective date ensures that validators who began their staking period without knowledge of the increased requirement are not retroactively penalized. This ACP was announced on February 10, 2026, and notifications were added in relevant places including the Core staking UI, block explorers, and validator uptime statistics dashboards. Helicon activation provides sufficient lead time for validators to adjust their infrastructure.
 
 ## Copyright
 


### PR DESCRIPTION
Updates the effective date to be based on Helicon activation, instead of a fixed April 1, 2026 date and a separate release-activation condition.

The two conditions in the original text ("started on or after April 1" and "hasn't ended before release activation") collapse into one, since both are now expressed relative to Helicon activation.
