### PR TITLE
docs: repoint dead docs.avax.network links at build.avax.network

### DIFF
--- a/ACPs/108-evm-event-importing/README.md
+++ b/ACPs/108-evm-event-importing/README.md
@@ -7,7 +7,7 @@
 
 ## Abstract
 
-Defines a standard smart contract interface and abstract implementation for importing EVM events from any blockchain within Avalanche using [Avalanche Warp Messaging](https://docs.avax.network/build/cross-chain/awm/overview).
+Defines a standard smart contract interface and abstract implementation for importing EVM events from any blockchain within Avalanche using [Avalanche Warp Messaging](https://build.avax.network/docs/cross-chain/avalanche-warp-messaging/overview).
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An Avalanche Community Proposal is a concise document that introduces a change or best practice for adoption on the [Avalanche Network](https://www.avax.com). ACPs should provide clear technical specifications of any proposals and a compelling rationale for their adoption.
 
-ACPs are an open framework for proposing improvements and gathering consensus around changes to the Avalanche Network. ACPs can be proposed by anyone and will be merged into this repository as long as they are well-formatted and coherent. Once an overwhelming majority of the Avalanche Network/Community have [signaled their support for an ACP](https://docs.avax.network/nodes/configure/avalanchego-config-flags#avalanche-community-proposals), it may be scheduled for activation on the Avalanche Network by Avalanche Network Clients (ANCs). It is ultimately up to members of the Avalanche Network/Community to adopt ACPs they support by running a compatible ANC, such as [AvalancheGo](https://github.com/ava-labs/avalanchego). 
+ACPs are an open framework for proposing improvements and gathering consensus around changes to the Avalanche Network. ACPs can be proposed by anyone and will be merged into this repository as long as they are well-formatted and coherent. Once an overwhelming majority of the Avalanche Network/Community have [signaled their support for an ACP](https://build.avax.network/docs/nodes/configure/configs-flags#avalanche-community-proposals), it may be scheduled for activation on the Avalanche Network by Avalanche Network Clients (ANCs). It is ultimately up to members of the Avalanche Network/Community to adopt ACPs they support by running a compatible ANC, such as [AvalancheGo](https://github.com/ava-labs/avalanchego). 
 
 ## ACP Tracks
 


### PR DESCRIPTION
## What changed

Two links point at `docs.avax.network`, which no longer serves those paths (both return 404). Avalanche docs live at `build.avax.network/docs`.

| File | Old (404) | New (200) |
| --- | --- | --- |
| `README.md` | `docs.avax.network/nodes/configure/avalanchego-config-flags#avalanche-community-proposals` | `build.avax.network/docs/nodes/configure/configs-flags#avalanche-community-proposals` |
| `ACPs/108-evm-event-importing/README.md` | `docs.avax.network/build/cross-chain/awm/overview` | `build.avax.network/docs/cross-chain/avalanche-warp-messaging/overview` |

The `#avalanche-community-proposals` anchor still resolves on the new page, which documents `--acp-support` and `--acp-object`.

## How it was verified

`curl -o /dev/null -w "%{http_code}"` on all four URLs: old two 404, new two 200. Anchor headings confirmed present on the target pages.

## Notes

The README link is the one that matters most: build.avax.network renders this README as https://build.avax.network/docs/acps, so the dead link is user-facing there. Happy to drop the ACP-108 commit if you would rather not touch a proposal's text for a link fix.